### PR TITLE
Add limitations to ascent logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "migration:run": "npm run typeorm migration:run",
     "migration:revert": "npm run typeorm migration:revert",
     "migration:generate": "npm run typeorm migration:generate -- -n",
+    "migration:create": "npm run typeorm migration:create -- -n",
     "migration:show": "npm run typeorm migration:show"
   },
   "dependencies": {

--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -8,7 +8,6 @@ import {
   ManyToOne,
 } from 'typeorm';
 import { ObjectType, Field, Int } from '@nestjs/graphql';
-import { Crag } from '../../crags/entities/crag.entity';
 import { Route } from '../../crags/entities/route.entity';
 import { Activity } from './activity.entity';
 import { Pitch } from '../../crags/entities/pitch.entity';
@@ -31,6 +30,12 @@ export enum AscentType {
   T_ATTEMPT = 't_attempt',
   TICK = 'tick',
 }
+
+export const tickAscentTypes = [
+  AscentType.ONSIGHT,
+  AscentType.FLASH,
+  AscentType.REDPOINT,
+];
 
 export enum PublishType {
   PUBLIC = 'public',

--- a/src/activities/resolvers/activities.resolver.ts
+++ b/src/activities/resolvers/activities.resolver.ts
@@ -14,10 +14,7 @@ import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
 
 @Resolver(() => Activity)
 export class ActivitiesResolver {
-  constructor(
-    private activitiesService: ActivitiesService,
-    private activityRoutesService: ActivityRoutesService,
-  ) {}
+  constructor(private activitiesService: ActivitiesService) {}
 
   @UseGuards(UserAuthGuard)
   @Query(() => PaginatedActivities)
@@ -41,16 +38,18 @@ export class ActivitiesResolver {
   async createActivity(
     @CurrentUser() user: User,
     @Args('input', { type: () => CreateActivityInput })
-    input: CreateActivityInput,
+    activityIn: CreateActivityInput,
     @Args('routes', { type: () => [CreateActivityRouteInput] })
-    routes: CreateActivityRouteInput[],
+    routesIn: CreateActivityRouteInput[],
   ): Promise<Activity> {
-    const activity = await this.activitiesService.create(input, user);
-
-    routes.forEach(async route => {
-      await this.activityRoutesService.create(route, user, activity);
-    });
-
-    return this.activitiesService.findOneById(activity.id);
+    try {
+      return this.activitiesService.createActivityWRoutes(
+        activityIn,
+        user,
+        routesIn,
+      );
+    } catch (exception) {
+      throw exception;
+    }
   }
 }

--- a/src/activities/resolvers/activity-routes.resolver.ts
+++ b/src/activities/resolvers/activity-routes.resolver.ts
@@ -7,10 +7,20 @@ import { FindActivityRoutesInput } from '../dtos/find-activity-routes.input';
 import { ActivityRoute } from '../entities/activity-route.entity';
 import { ActivityRoutesService } from '../services/activity-routes.service';
 import { PaginatedActivityRoutes } from '../utils/paginated-activity-routes.class';
+import { RouteTouched } from '../utils/route-touched.class';
 
 @Resolver()
 export class ActivityRoutesResolver {
   constructor(private activityRoutesService: ActivityRoutesService) {}
+
+  /**
+   * find out if currently logged in user has already tried and/or ticked a certain route
+   */
+  @UseGuards(UserAuthGuard)
+  @Query(() => RouteTouched)
+  routeTouched(@CurrentUser() user: User, @Args('routeId') routeId: string) {
+    return this.activityRoutesService.routeTouched(user, routeId);
+  }
 
   @UseGuards(UserAuthGuard)
   @Query(() => PaginatedActivityRoutes)

--- a/src/activities/utils/route-touched.class.ts
+++ b/src/activities/utils/route-touched.class.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class RouteTouched {
+  @Field()
+  tried: boolean;
+
+  @Field()
+  ticked: boolean;
+}

--- a/src/migration/1640769431575-convertBoulderFlashToOnsight.ts
+++ b/src/migration/1640769431575-convertBoulderFlashToOnsight.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class convertBoulderFlashToOnsight1640769431575
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        WITH issightiswrong AS (
+            SELECT ar.id
+            FROM activity_route ar
+            LEFT JOIN route r ON ar."routeId" = r.id
+            WHERE r."routeTypeId" = 'boulder'
+            AND ar."ascentType" = 'onsight'
+        )
+        UPDATE activity_route ar
+        SET "ascentType" = 'flash'
+        FROM issightiswrong
+        WHERE ar.id = issightiswrong.id;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        WITH isflashtowrongsight AS (
+            SELECT ar.id
+            FROM activity_route ar
+            LEFT JOIN route r on r.id = ar."routeId"
+            WHERE r."routeTypeId" = 'boulder'
+            AND ar."ascentType" = 'flash'
+            AND (ar.legacy::json -> 'AscentType')::jsonb = '"S"'::jsonb
+        )
+        UPDATE activity_route ar
+        SET "ascentType" = 'onsight'
+        FROM isflashtowrongsight
+        WHERE ar.id = isflashtowrongsight.id;
+      `);
+  }
+}


### PR DESCRIPTION
 based on previous ascents of a route and based on route type.


Way to test this: 
Keep FE on master branch (do it before reject-impossible-logs PR is merged on FE).
Go to a crag and try to log a route with an impossible selection of ascent type.
Limitations are:
- boulders cannot be onsighted. (First try ascent can only be a flash.)
- any route that has already been tried cannot be onsighted or flashed
- any route that has already been ticked cannot be onsighted, flashed or redpointed (can only be repeated)

