### PR TITLE
Add or update difficulty vote if passed alongside activity-route.

### DIFF
--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -13,6 +13,7 @@ import { ActivityRoutesService } from './services/activity-routes.service';
 import { UsersModule } from '../users/users.module';
 import { ClubMember } from '../users/entities/club-member.entity';
 import { Club } from '../users/entities/club.entity';
+import { DifficultyVote } from '../crags/entities/difficulty-vote.entity';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { Club } from '../users/entities/club.entity';
       Pitch,
       ClubMember,
       Club,
+      DifficultyVote,
     ]),
     AuditModule,
     UsersModule,

--- a/src/activities/dtos/create-activity-route.input.ts
+++ b/src/activities/dtos/create-activity-route.input.ts
@@ -32,13 +32,9 @@ export class CreateActivityRouteInput {
   @IsOptional()
   position: number;
 
-  @Field({ nullable: true })
-  @IsOptional()
-  grade: number;
-
   @Field(type => Float, { nullable: true })
   @IsOptional()
-  difficulty: number;
+  votedDifficulty: number;
 
   @Field({ nullable: true })
   @IsOptional()

--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -35,6 +35,7 @@ export const tickAscentTypes = [
   AscentType.ONSIGHT,
   AscentType.FLASH,
   AscentType.REDPOINT,
+  AscentType.REPEAT,
 ];
 
 export enum PublishType {

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -85,6 +85,13 @@ export class ActivityRoutesService {
         }
         difficultyVote.difficulty = routeIn.votedDifficulty;
 
+        // if a route that is being ticked is/was a project, then the first vote is a base vote, and the route ceases to be a project
+        if (route.isProject) {
+          difficultyVote.isBase = true;
+          route.isProject = false;
+          await queryRunner.manager.save(route);
+        }
+
         await queryRunner.manager.save(difficultyVote);
       }
     }

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -66,6 +66,14 @@ export class ActivityRoutesService {
 
       // if a vote on difficulty is passed add a new difficulty vote or update existing
       if (routeIn.votedDifficulty) {
+        // but first check if a user even can vote (can vote only if the log is a tick)
+        if (!tickAscentTypes.some(at => at === routeIn.ascentType)) {
+          throw new HttpException(
+            'Cannot vote on difficulty if not a tick',
+            HttpStatus.NOT_ACCEPTABLE,
+          );
+        }
+
         let difficultyVote = await this.difficultyVoteRepository.findOne({
           user,
           route,

--- a/src/crags/entities/difficulty-vote.entity.ts
+++ b/src/crags/entities/difficulty-vote.entity.ts
@@ -50,7 +50,7 @@ export class DifficultyVote extends BaseEntity {
   @Field()
   includedInCalculation: boolean;
 
-  @Column({ nullable: true })
+  @Column({ default: false })
   @Field()
   isBase: boolean;
 }

--- a/src/crags/entities/difficulty-vote.entity.ts
+++ b/src/crags/entities/difficulty-vote.entity.ts
@@ -6,12 +6,14 @@ import {
   UpdateDateColumn,
   BaseEntity,
   ManyToOne,
+  Unique,
 } from 'typeorm';
 import { ObjectType, Field } from '@nestjs/graphql';
 import { User } from '../../users/entities/user.entity';
 import { Route } from './route.entity';
 
 @Entity()
+@Unique(['route', 'user'])
 @ObjectType()
 export class DifficultyVote extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/src/migration/1640808395495-userRouteUniqueConstraintOnDiffVote.ts
+++ b/src/migration/1640808395495-userRouteUniqueConstraintOnDiffVote.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class userRouteUniqueConstraintOnDiffVote1640808395495 implements MigrationInterface {
+    name = 'userRouteUniqueConstraintOnDiffVote1640808395495'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" ALTER COLUMN "includedInCalculation" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" ALTER COLUMN "includedInCalculation" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" ADD CONSTRAINT "UQ_94157d2971371af83a760bd0c3a" UNIQUE ("routeId", "userId")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" DROP CONSTRAINT "UQ_94157d2971371af83a760bd0c3a"`);
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" ALTER COLUMN "includedInCalculation" SET DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "difficulty_vote" ALTER COLUMN "includedInCalculation" SET NOT NULL`);
+    }
+
+}

--- a/src/migration/1641581329593-addDefaultIsNotBaseToDifficultyVote.ts
+++ b/src/migration/1641581329593-addDefaultIsNotBaseToDifficultyVote.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addDefaultIsNotBaseToDifficultyVote1641581329593
+  implements MigrationInterface {
+  name = 'addDefaultIsNotBaseToDifficultyVote1641581329593';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "isBase" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "isBase" SET DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "isBase" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "isBase" DROP NOT NULL`,
+    );
+  }
+}


### PR DESCRIPTION
Saves difficulty vote do db or updates it if a user already voted on a route. 
Everything else happens on db level (route difficulty recalculation).

To test this use Firecamp to send createActivity mutation to BE, then observe difficulty_vote and route tables in db.