### PR TITLE
Order grades by difficulty

### DIFF
--- a/src/crags/services/grading-systems.service.ts
+++ b/src/crags/services/grading-systems.service.ts
@@ -11,8 +11,10 @@ export class GradingSystemsService {
   ) {}
 
   async find(): Promise<GradingSystem[]> {
-    return this.gradingSystemRepository.find({
-      order: { position: 'ASC' },
-    });
+    return this.gradingSystemRepository
+      .createQueryBuilder('gradingSystem')
+      .leftJoinAndSelect('gradingSystem.grades', 'grades')
+      .orderBy({ 'gradingSystem.position': 'ASC', 'grades.difficulty': 'ASC' })
+      .getMany();
   }
 }


### PR DESCRIPTION
Grades returned should be ordered by difficulty, as FE service expects them to be.

To test check a bouldering area on crags list to see that before the fix the grades were wrongly transformed from difficulty.