### PR TITLE
add route_events entity and migration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -33,6 +33,7 @@ import { userLoader } from './crags/loaders/user.loader';
 import { RouteType } from './crags/entities/route-type.entity';
 import { GradingSystem } from './crags/entities/grading-system.entity';
 import { Grade } from './crags/entities/grade.entity';
+import { RouteEvent } from './crags/entities/route-event.entity';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { Grade } from './crags/entities/grade.entity';
           IceFall,
           Rating,
           RouteType,
+          RouteEvent,
           GradingSystem,
           Grade,
         ],

--- a/src/crags/entities/route-event.entity.ts
+++ b/src/crags/entities/route-event.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  Column,
+  BaseEntity,
+  PrimaryColumn,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ObjectType, Field } from '@nestjs/graphql';
+import { Route } from './route.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class RouteEvent extends BaseEntity {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  author: string;
+
+  @ManyToOne(
+    () => Route,
+    route => route.routeEvents,
+  )
+  route: Promise<Route>;
+
+  // this can be converted to enum when we start actually using this entity
+  @Column({ nullable: true })
+  eventType: string;
+
+  @Column()
+  eventDate: Date;
+
+  @ManyToOne(() => User)
+  @Field(() => User, { nullable: true })
+  user: Promise<User>;
+
+  @Column({ default: true })
+  showFullDate: boolean;
+
+  @CreateDateColumn()
+  created: Date;
+
+  @UpdateDateColumn()
+  updated: Date;
+
+  @Column({ nullable: true })
+  legacy: string;
+}

--- a/src/crags/entities/route-event.entity.ts
+++ b/src/crags/entities/route-event.entity.ts
@@ -33,7 +33,6 @@ export class RouteEvent extends BaseEntity {
   eventDate: Date;
 
   @ManyToOne(() => User)
-  @Field(() => User, { nullable: true })
   user: Promise<User>;
 
   @Column({ default: true })

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -154,6 +154,5 @@ export class Route extends BaseEntity {
     routeEvent => routeEvent.route,
     { nullable: true },
   )
-  @Field(() => [RouteEvent])
   routeEvents: Promise<RouteEvent[]>;
 }

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -19,6 +19,7 @@ import { Crag } from './crag.entity';
 import { Rating } from './rating.entity';
 import { GradingSystem } from './grading-system.entity';
 import { RouteType } from './route-type.entity';
+import { RouteEvent } from './route-event.entity';
 
 export enum RouteStatus {
   PUBLIC = 'public',
@@ -147,4 +148,12 @@ export class Route extends BaseEntity {
   )
   @Field(() => [Image])
   images: Promise<Image[]>;
+
+  @OneToMany(
+    () => RouteEvent,
+    routeEvent => routeEvent.route,
+    { nullable: true },
+  )
+  @Field(() => [RouteEvent])
+  routeEvents: Promise<RouteEvent[]>;
 }

--- a/src/migration/1642083807909-route-events.ts
+++ b/src/migration/1642083807909-route-events.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class routeEvents1642083807909 implements MigrationInterface {
+    name = 'routeEvents1642083807909'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "route_event" ("id" character varying NOT NULL, "author" character varying NOT NULL, "eventType" character varying, "eventDate" TIMESTAMP NOT NULL, "showFullDate" boolean NOT NULL DEFAULT true, "created" TIMESTAMP NOT NULL DEFAULT now(), "updated" TIMESTAMP NOT NULL DEFAULT now(), "legacy" character varying, "routeId" uuid, "userId" uuid, CONSTRAINT "PK_71f2e1858117ffff5f16c74452a" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "route_event" ADD CONSTRAINT "FK_2504808be354765577883a52e63" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "route_event" ADD CONSTRAINT "FK_04b73fdbc27bd862c2e360e787f" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "route_event" DROP CONSTRAINT "FK_04b73fdbc27bd862c2e360e787f"`);
+        await queryRunner.query(`ALTER TABLE "route_event" DROP CONSTRAINT "FK_2504808be354765577883a52e63"`);
+        await queryRunner.query(`DROP TABLE "route_event"`);
+    }
+
+}


### PR DESCRIPTION
Testing: just see that the database migration goes through. The table will be filled with migration script. We will figure out how to do it later with another feature request.

closes #53 
closes #51 