### PR TITLE
Warnings exposedUntil field

### DIFF
--- a/src/crags/dtos/create-comment.input.ts
+++ b/src/crags/dtos/create-comment.input.ts
@@ -25,4 +25,8 @@ export class CreateCommentInput {
   @Field({ nullable: true })
   @IsOptional()
   peakId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  exposedUntil: Date;
 }

--- a/src/crags/dtos/update-comment.ts
+++ b/src/crags/dtos/update-comment.ts
@@ -1,4 +1,5 @@
 import { InputType, Field } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
 
 @InputType()
 export class UpdateCommentInput {
@@ -7,4 +8,8 @@ export class UpdateCommentInput {
 
   @Field()
   content: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  exposedUntil: Date;
 }

--- a/src/crags/entities/comment.entity.ts
+++ b/src/crags/entities/comment.entity.ts
@@ -92,7 +92,7 @@ export class Comment extends BaseEntity {
   routeId: string;
 
   @Column({ nullable: true }) // keep nullable, only comments of type=warning use this field
-  @Field()
+  @Field({ nullable: true })
   exposedUntil: Date;
 
   @ManyToOne(

--- a/src/crags/services/comments.service.ts
+++ b/src/crags/services/comments.service.ts
@@ -1,7 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../users/entities/user.entity';
-import { FindManyOptions, In, Repository, MoreThanOrEqual } from 'typeorm';
+import { FindManyOptions, In, Repository, Raw } from 'typeorm';
 import { CreateCommentInput } from '../dtos/create-comment.input';
 import { FindCommentsInput } from '../dtos/find-comments.input';
 import { UpdateCommentInput } from '../dtos/update-comment';
@@ -108,7 +108,7 @@ export class CommentsService {
     return this.commentsRepository.find({
       where: {
         type: 'warning',
-        exposedUntil: MoreThanOrEqual('2021-12-03'),
+        exposedUntil: Raw(exun => `${exun} > NOW()`),
       },
       order: { updated: 'DESC' },
     });


### PR DESCRIPTION
Add exposedUntil to comments dtos. Check exposedUntil is valid if passed.

Test this by posting exposedUntil field when saving or editing a comment of type warning.
Check date date that is more than 1 month into the future is denied.