### PR TITLE
Fix role middleware

### DIFF
--- a/src/core/middleware/check-role.middleware.ts
+++ b/src/core/middleware/check-role.middleware.ts
@@ -1,4 +1,5 @@
 import { FieldMiddleware, MiddlewareContext, NextFn } from '@nestjs/graphql';
+import { Role } from '../../users/entities/role.entity';
 
 export const checkRoleMiddleware: FieldMiddleware = async (
   ctx: MiddlewareContext,
@@ -17,7 +18,7 @@ export const checkRoleMiddleware: FieldMiddleware = async (
     return next();
   }
 
-  if (user.roles.some((r: string) => roles.includes(r))) {
+  if (user.roles.some((r: Role) => roles.includes(r.role))) {
     return next();
   }
 


### PR DESCRIPTION
User object in context has array of role objects (not array of strings).
You can test this by querying a user and trying to get a protected field (eg. user email)
(before this PR it will not work even when you do have an admin role)

nb that directly querying user will not work since user query does not have an auth guard, hence no user object in context.
Try querying for example myClubs, with user subfields...
