### PR TITLE
Add crag type column to crag entity

### DIFF
--- a/src/crags/dtos/create-route.input.ts
+++ b/src/crags/dtos/create-route.input.ts
@@ -33,4 +33,8 @@ export class CreateRouteInput {
 
   @Field()
   defaultGradingSystemId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  baseDifficulty: number;
 }

--- a/src/crags/dtos/create-route.input.ts
+++ b/src/crags/dtos/create-route.input.ts
@@ -1,5 +1,5 @@
 import { InputType, Field } from '@nestjs/graphql';
-import { IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
 import { RouteStatus } from '../entities/route.entity';
 
 @InputType()
@@ -7,10 +7,12 @@ export class CreateRouteInput {
   @Field()
   name: string;
 
-  @Field()
+  @Field({ nullable: true })
+  @IsOptional()
   length: string;
 
-  @Field()
+  @Field({ nullable: true })
+  @IsOptional()
   author: string;
 
   @Field()
@@ -22,4 +24,13 @@ export class CreateRouteInput {
   @IsUUID()
   @Field()
   sectorId: string;
+
+  @Field()
+  isProject: boolean;
+
+  @Field()
+  routeTypeId: string;
+
+  @Field()
+  defaultGradingSystemId: string;
 }

--- a/src/crags/dtos/update-route.input.ts
+++ b/src/crags/dtos/update-route.input.ts
@@ -13,6 +13,10 @@ export class UpdateRouteInput {
 
   @Field({ nullable: true })
   @IsOptional()
+  length: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
   author: string;
 
   @Field({ nullable: true })
@@ -30,4 +34,12 @@ export class UpdateRouteInput {
   @Field({ nullable: true })
   @IsOptional()
   sectorId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  routeTypeId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  defaultGradingSystemId: string;
 }

--- a/src/crags/entities/crag.entity.ts
+++ b/src/crags/entities/crag.entity.ts
@@ -31,6 +31,11 @@ export enum CragStatus {
   USER = 'user',
 }
 
+export enum CragType {
+  SPORT = 'sport',
+  ALPINE = 'alpine',
+}
+
 @Entity()
 @ObjectType()
 export class Crag extends BaseEntity {
@@ -45,6 +50,14 @@ export class Crag extends BaseEntity {
   @Column({ unique: true })
   @Field()
   slug: string;
+
+  @Column({
+    type: 'enum',
+    enum: CragType,
+    default: CragType.SPORT,
+  })
+  @Field()
+  type: CragType;
 
   @Column({
     type: 'enum',

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -61,7 +61,7 @@ export class Route extends BaseEntity {
   defaultGradingSystem: Promise<GradingSystem>;
 
   @Column({ type: 'int', nullable: true })
-  @Field()
+  @Field({ nullable: true })
   length: string;
 
   @Column({ nullable: true })
@@ -69,6 +69,7 @@ export class Route extends BaseEntity {
   author: string;
 
   @Column({ type: 'int' })
+  @Field()
   position: number;
 
   @Column({

--- a/src/crags/entities/sector.entity.ts
+++ b/src/crags/entities/sector.entity.ts
@@ -37,6 +37,7 @@ export class Sector extends BaseEntity {
   label: string;
 
   @Column({ type: 'int' })
+  @Field()
   position: number;
 
   @Column({

--- a/src/crags/resolvers/routes.resolver.ts
+++ b/src/crags/resolvers/routes.resolver.ts
@@ -58,6 +58,17 @@ export class RoutesResolver {
     return this.routesService.update(input);
   }
 
+  @Mutation(() => [Route])
+  @Roles('admin')
+  @UseInterceptors(AuditInterceptor)
+  @UseFilters(NotFoundFilter)
+  async updateRoutes(
+    @Args('input', { type: () => [UpdateRouteInput] })
+    input: UpdateRouteInput[],
+  ): Promise<Route[]> {
+    return Promise.all(input.map(input => this.routesService.update(input)));
+  }
+
   @Mutation(() => Boolean)
   @Roles('admin')
   @UseInterceptors(AuditInterceptor)

--- a/src/crags/services/sectors.service.ts
+++ b/src/crags/services/sectors.service.ts
@@ -25,6 +25,10 @@ export class SectorsService {
     });
   }
 
+  async findOneById(id: string): Promise<Sector> {
+    return this.sectorsRepository.findOneOrFail(id);
+  }
+
   async create(data: CreateSectorInput): Promise<Sector> {
     const sector = new Sector();
 

--- a/src/migration/1642708669831-add-crag-type.ts
+++ b/src/migration/1642708669831-add-crag-type.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addCragType1642708669831 implements MigrationInterface {
+  name = 'addCragType1642708669831';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."crag_type_enum" AS ENUM('sport', 'alpine')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "crag" ADD "type" "public"."crag_type_enum" NOT NULL DEFAULT 'sport'`,
+    );
+    await queryRunner.query(
+      `UPDATE "crag" set "type" = 'alpine' WHERE "peakId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "crag" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "public"."crag_type_enum"`);
+  }
+}


### PR DESCRIPTION
Creates a new field "type" to the crag entity. It will be used to separate the sport climbing (includes bouldering and sport multipitches) and alpine crags (walls?).
Migration sets all the crags that have peakId filled to alpine. 