### PR TITLE
add crag type property to crags

### DIFF
--- a/src/crags/entities/crag.entity.ts
+++ b/src/crags/entities/crag.entity.ts
@@ -31,6 +31,11 @@ export enum CragStatus {
   USER = 'user',
 }
 
+export enum CragType {
+  SPORT = 'sport',
+  ALPINE = 'alpine',
+}
+
 @Entity()
 @ObjectType()
 export class Crag extends BaseEntity {
@@ -45,6 +50,14 @@ export class Crag extends BaseEntity {
   @Column({ unique: true })
   @Field()
   slug: string;
+
+  @Column({
+    type: 'enum',
+    enum: CragType,
+    default: CragType.SPORT,
+  })
+  @Field()
+  type: CragType;
 
   @Column({
     type: 'enum',

--- a/src/migration/1642708669831-add-crag-type.ts
+++ b/src/migration/1642708669831-add-crag-type.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addCragType1642708669831 implements MigrationInterface {
+  name = 'addCragType1642708669831';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."crag_type_enum" AS ENUM('sport', 'alpine')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "crag" ADD "type" "public"."crag_type_enum" NOT NULL DEFAULT 'sport'`,
+    );
+    await queryRunner.query(
+      `UPDATE "crag" set "type" = 'alpine' WHERE "peakId" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "crag" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "public"."crag_type_enum"`);
+  }
+}


### PR DESCRIPTION
Creates a new field "type" to the crag entity. It will be used to separate the sport climbing (includes bouldering and sport multipitches) and alpine crags (walls?).
Migration sets all the crags that have peakId filled to alpine.