### PR TITLE
Grading system route type jointable

### DIFF
--- a/src/crags/entities/grading-system.entity.ts
+++ b/src/crags/entities/grading-system.entity.ts
@@ -5,6 +5,7 @@ import {
   PrimaryColumn,
   ManyToMany,
   OneToMany,
+  JoinTable,
 } from 'typeorm';
 import { ObjectType, Field } from '@nestjs/graphql';
 import { RouteType } from './route-type.entity';
@@ -23,8 +24,12 @@ export class GradingSystem extends BaseEntity {
   @Column({ type: 'int' })
   position: number;
 
-  @ManyToMany(() => RouteType)
-  routeTypes: RouteType[];
+  @ManyToMany(() => RouteType, { nullable: true })
+  @Field(() => [RouteType])
+  @JoinTable({
+    name: 'grading_system_route_type',
+  })
+  routeTypes: Promise<RouteType[]>;
 
   @OneToMany(
     () => Grade,

--- a/src/crags/entities/route-type.entity.ts
+++ b/src/crags/entities/route-type.entity.ts
@@ -19,11 +19,12 @@ export class RouteType extends BaseEntity {
   @Field()
   name: string;
 
-  @ManyToMany(() => GradingSystem)
+  @ManyToMany(() => GradingSystem, { nullable: true })
+  @Field(() => [GradingSystem])
   @JoinTable({
-    name: "grading_system_route_type"
+    name: 'grading_system_route_type',
   })
-  gradingSystems: GradingSystem[];
+  gradingSystems: Promise<GradingSystem[]>;
 
   @Column({ type: 'int' })
   position: number;

--- a/src/migration/1642796663094-grading-system-route-type.ts
+++ b/src/migration/1642796663094-grading-system-route-type.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class gradingSystemRouteType1642796663094 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`truncate table grading_system_route_type;`);
+    await queryRunner.query(
+      `insert into grading_system_route_type select * from route_type_grading_system;`,
+    );
+    await queryRunner.query(`drop table route_type_grading_system;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "route_type_grading_system" ("routeTypeId" character varying NOT NULL, "gradingSystemId" character varying NOT NULL, CONSTRAINT "PK_58dbc4abf8b467c7470cdbff052" PRIMARY KEY ("routeTypeId", "gradingSystemId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_876495711515bf4f3b34f8172f" ON "route_type_grading_system" ("routeTypeId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_874ecc4fd3a131710ddc26558a" ON "route_type_grading_system" ("gradingSystemId") `,
+    );
+
+    await queryRunner.query(`truncate table route_type_grading_system;`);
+
+    await queryRunner.query(
+      `insert into route_type_grading_system select * from grading_system_route_type;`,
+    );
+  }
+}


### PR DESCRIPTION
set up grading system <-> route type fields,
make the fields use the correct single join table
update migration to delete the other table

test by running the migration, checking the database and running the following gql:
`{
  gradingSystems {
    id
    name
    routeTypes {
      name
      gradingSystems {
        name
      }
    }
  }
}
`