### PR TITLE
Activity route sorting

### DIFF
--- a/src/activities/dtos/find-activity-routes.input.ts
+++ b/src/activities/dtos/find-activity-routes.input.ts
@@ -7,6 +7,10 @@ import { AscentType, PublishType } from '../entities/activity-route.entity';
 export class FindActivityRoutesInput {
   @Field({ nullable: true })
   @IsOptional()
+  activityId?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
   userId?: string;
 
   @Field({ nullable: true })

--- a/src/activities/resolvers/activities.resolver.ts
+++ b/src/activities/resolvers/activities.resolver.ts
@@ -1,5 +1,12 @@
 import { UseFilters, UseGuards } from '@nestjs/common';
-import { Resolver, Query, Args, Mutation } from '@nestjs/graphql';
+import {
+  Resolver,
+  Query,
+  Args,
+  Mutation,
+  ResolveField,
+  Parent,
+} from '@nestjs/graphql';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { User } from '../../users/entities/user.entity';
 import { Activity } from '../entities/activity.entity';
@@ -11,10 +18,14 @@ import { CreateActivityRouteInput } from '../dtos/create-activity-route.input';
 import { ActivityRoutesService } from '../services/activity-routes.service';
 import { NotFoundFilter } from '../../crags/filters/not-found.filter';
 import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
+import { ActivityRoute } from '../entities/activity-route.entity';
 
 @Resolver(() => Activity)
 export class ActivitiesResolver {
-  constructor(private activitiesService: ActivitiesService) {}
+  constructor(
+    private activitiesService: ActivitiesService,
+    private activityRoutesService: ActivityRoutesService,
+  ) {}
 
   @UseGuards(UserAuthGuard)
   @Query(() => PaginatedActivities)
@@ -51,5 +62,12 @@ export class ActivitiesResolver {
     } catch (exception) {
       throw exception;
     }
+  }
+
+  @ResolveField('routes', () => [ActivityRoute])
+  async getRoutes(@Parent() activity: Activity): Promise<ActivityRoute[]> {
+    return this.activityRoutesService.find({
+      activityId: activity.id,
+    });
   }
 }

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -321,11 +321,12 @@ export class ActivityRoutesService {
   ): SelectQueryBuilder<ActivityRoute> {
     const builder = this.activityRoutesRepository.createQueryBuilder('ar');
 
+    builder.innerJoin('route', 'r', 'r.id = ar."routeId"');
+    builder.addSelect('r.difficulty');
+
     if (params.orderBy != null) {
       builder.orderBy(
-        params.orderBy.field != null
-          ? 'ar.' + params.orderBy.field
-          : 'ar.created',
+        this.orderByField(params.orderBy.field),
         params.orderBy.direction || 'DESC',
       );
 
@@ -334,7 +335,7 @@ export class ActivityRoutesService {
         params.orderBy.field === 'date' ? params.orderBy.direction : 'DESC',
       );
     } else {
-      builder.orderBy('ar.created', 'DESC').addOrderBy('ar.position', 'DESC'); // TODO: can we even come here ever?
+      builder.orderBy('ar.created', 'DESC').addOrderBy('ar.position', 'DESC');
     }
 
     if (params.cragId != null) {
@@ -347,11 +348,6 @@ export class ActivityRoutesService {
         cragId: params.cragId,
       });
     }
-
-    // TODO: fix after grade->difficulty change
-    // if (params.orderBy != null && params.orderBy.field == 'grade') {
-    //   builder.andWhere('ar.grade IS NOT NULL');
-    // }
 
     if (params.userId != null) {
       builder.andWhere('ar."userId" = :userId', {
@@ -383,6 +379,24 @@ export class ActivityRoutesService {
       builder.andWhere('ar."routeId" = :routeId', { routeId: params.routeId });
     }
 
+    if (params.activityId != null) {
+      builder.andWhere('ar."activityId" = :activityId', {
+        activityId: params.activityId,
+      });
+    }
+
     return builder;
+  }
+
+  private orderByField(field: string) {
+    if (field == null) {
+      return 'ar.created';
+    }
+
+    if (field == 'grade') {
+      return 'r.difficulty';
+    }
+
+    return `ar.${field}`;
   }
 }


### PR DESCRIPTION
Joined route table in activity routes service find conditions so sorting by grade now works in activity log.
Added resolve field to activity resolver so routes are resolved via service and therefore sorted properly.

To test it open up your climbing log and sort by grade, then open a climbing day, refresh a few times and see that the order of routes does not change.