### PR TITLE
Individual pitches logged

### DIFF
--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -74,6 +74,7 @@ export class ActivityRoute extends BaseEntity {
   route: Promise<Route>;
 
   @ManyToOne(() => Pitch, { nullable: true })
+  @Field(type => Pitch, { nullable: true })
   pitch: Promise<Route>;
 
   @Column({

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -324,6 +324,10 @@ export class ActivityRoutesService {
     builder.innerJoin('route', 'r', 'r.id = ar."routeId"');
     builder.addSelect('r.difficulty');
 
+    builder.leftJoin('pitch', 'p', 'p.id = ar."pitchId"');
+    builder.addSelect('p.difficulty');
+    builder.addSelect('coalesce(p.difficulty, r.difficulty)', 'difficulty');
+
     if (params.orderBy != null) {
       builder.orderBy(
         this.orderByField(params.orderBy.field),
@@ -394,7 +398,7 @@ export class ActivityRoutesService {
     }
 
     if (field == 'grade') {
-      return 'r.difficulty';
+      return 'difficulty';
     }
 
     return `ar.${field}`;

--- a/src/crags/entities/pitch.entity.ts
+++ b/src/crags/entities/pitch.entity.ts
@@ -28,9 +28,13 @@ export class Pitch extends BaseEntity {
   @Field()
   number: number;
 
-  @Column({ nullable: true })
+  @Column({ type: 'float', nullable: true })
+  @Field({ nullable: true })
+  difficulty: number;
+
+  @Column({ default: false })
   @Field()
-  difficulty: string;
+  isProject: boolean;
 
   @Column({ type: 'int', nullable: true })
   @Field()

--- a/src/migration/1644437266639-makePitchDifficultyANumber.ts
+++ b/src/migration/1644437266639-makePitchDifficultyANumber.ts
@@ -1,0 +1,118 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class makePitchDifficultyANumber1644437266639
+  implements MigrationInterface {
+  name = 'makePitchDifficultyANumber1644437266639';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pitch" ADD "difficultyTemp" double precision`,
+    );
+
+    // update most of the pitches by looking up the grade table
+    await queryRunner.query(`
+        UPDATE pitch p
+            SET "difficultyTemp" = (
+                SELECT g.difficulty
+                FROM grade AS g
+                WHERE g."gradingSystemId"='french' AND g.name = p.difficulty
+            )`);
+
+    // get pitches for which the grade/diffiiculty pair hasn't been found
+    const pitches = await queryRunner.query(
+      `SELECT id, difficulty FROM pitch WHERE "difficultyTemp" IS NULL order by difficulty`,
+    );
+
+    // manually convert grade to difficulty by custom lookup below
+    pitches.forEach(async pitch => {
+      const difficulty = this.gradeToDifficulty(pitch.difficulty);
+      if (difficulty) {
+        await queryRunner.query(
+          `UPDATE pitch SET "difficultyTemp" = ${difficulty} WHERE id = '${pitch.id}'`,
+        );
+      }
+    });
+
+    // for these few remaining special cases do a custom update
+    // these two pitches belong to route Stara in Osp, and today have a grade (it used to be P or A0)
+    await queryRunner.query(`UPDATE pitch SET "difficultyTemp" = 1750
+        WHERE (legacy::json -> 'PitchID')::JSONB = '828' OR  (legacy::json -> 'PitchID')::JSONB = '827'`);
+    // therefore we should also update the route's difficulty>
+    await queryRunner.query(`UPDATE difficulty_vote SET difficulty = 1750 
+        WHERE "routeId" = (SELECT "routeId" FROM pitch WHERE (legacy::json -> 'PitchID')::JSONB = '828') AND "isBase" = true`);
+
+    // last two pitches seem to be projects so we need isProject flag on pitch table as well
+    await queryRunner.query(
+      `ALTER TABLE "pitch" ADD "isProject" boolean NOT NULL DEFAULT false`,
+    );
+    // then set the remaining two pitches to project and set their difficulty to null
+    await queryRunner.query(`UPDATE pitch SET "difficultyTemp" = null, "isProject" = true
+        WHERE (legacy::json -> 'PitchID')::JSONB = '1910' OR  (legacy::json -> 'PitchID')::JSONB = '1373'`);
+
+    // we can now drop the column difficulty (string), and rename difficultyTemp to difficulty (number)
+    await queryRunner.query(`ALTER TABLE "pitch" DROP COLUMN "difficulty"`);
+    await queryRunner.query(
+      `ALTER TABLE "pitch" RENAME COLUMN "difficultyTemp" TO "difficulty"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "pitch" DROP COLUMN "difficultyTemp"`);
+    await queryRunner.query(`ALTER TABLE "pitch" DROP COLUMN "isProject"`);
+    await queryRunner.query(
+      `ALTER TABLE "pitch" ADD "difficulty" character varying`,
+    );
+  }
+
+  gradeToDifficulty(grade: string) {
+    switch (grade) {
+      case '1-2':
+        return 150;
+      case '3a':
+        return 300;
+      case '4':
+        return 400;
+      case '5':
+        return 600;
+      case '5+':
+      case '5a/A1':
+        return 700;
+      case '5b/A1':
+        return 800;
+      case '5c/6a':
+        return 975;
+      case '6a/a+':
+        return 1025;
+      case '6a/A0':
+        return 1000;
+      case '6a/A1':
+        return 1000;
+      case '6a+/b':
+        return 1075;
+      case '6b/A0':
+        return 1100;
+      case '6c+/7a':
+        return 1275;
+      case '6c+/A0':
+        return 1250;
+      case '6c/A0':
+        return 1200;
+      case '6c/c+':
+        return 1225;
+      case '7a+?':
+        return 1350;
+      case '7a/a+':
+        return 1325;
+      case '7a+/b':
+        return 1375;
+      case '7b+/c':
+        return 1475;
+      case '7c+/8a':
+        return 1575;
+      case '8a/a+':
+        return 1625;
+      default:
+        return false;
+    }
+  }
+}


### PR DESCRIPTION
This PR converts pitch difficulty from old string value to new float value that is then used to display grades.

It also adds some logic to sorting activity-routes by grade when a 'route' is actually a single pitch. 

This probably needs more treatment in the future but is a quick fix for properly displaying logs of individual pitches.

Test this with plezanje-net/web#171