### PR TITLE
Registration gender

### DIFF
--- a/src/notification/services/notification.service.ts
+++ b/src/notification/services/notification.service.ts
@@ -20,7 +20,7 @@ export class NotificationService {
         templateParams: {
           user: user,
           userGender: {
-            unknown: !user.gender,
+            unknown: !user.gender || user.gender === 'O',
             female: user.gender && user.gender === 'F',
           },
           url:
@@ -47,7 +47,7 @@ export class NotificationService {
         templateParams: {
           user: user,
           userGender: {
-            unknown: !user.gender,
+            unknown: !user.gender || user.gender === 'O',
             female: user.gender && user.gender === 'F',
           },
           url:
@@ -78,12 +78,12 @@ export class NotificationService {
         templateParams: {
           userAdding: userAdding,
           userAddingGender: {
-            unknown: !userAdding.gender,
+            unknown: !userAdding.gender || userAdding.gender === 'O',
             female: userAdding.gender && userAdding.gender === 'F',
           },
           clubMemberUser: clubMemberUser,
           clubMemberUserGender: {
-            unknown: !clubMemberUser.gender,
+            unknown: !clubMemberUser.gender || clubMemberUser.gender === 'O',
             female: clubMemberUser.gender && clubMemberUser.gender === 'F',
             male: clubMemberUser.gender && clubMemberUser.gender === 'M',
           },

--- a/src/users/dtos/register.input.ts
+++ b/src/users/dtos/register.input.ts
@@ -16,4 +16,7 @@ export class RegisterInput {
 
   @Field()
   lastname: string;
+
+  @Field({ nullable: true })
+  gender?: string;
 }


### PR DESCRIPTION
This PR adds gender to register mutation input. 

It also fixes some gender interpretations on emails as now am O (other) gender type is also possible.

To test no.1 try invoking the register mutation through Firecamp and set gender in input.
To test no.2 go through all processes that send emails using different gender users and check messages.

Can also test with WEB PR plezanje-net/web#194
