### PR TITLE
Make pitch height nullable.

### DIFF
--- a/src/crags/entities/pitch.entity.ts
+++ b/src/crags/entities/pitch.entity.ts
@@ -37,7 +37,7 @@ export class Pitch extends BaseEntity {
   isProject: boolean;
 
   @Column({ type: 'int', nullable: true })
-  @Field()
+  @Field({ nullable: true })
   height: number;
 
   @CreateDateColumn()


### PR DESCRIPTION
This fixes fails on some crags that contain routes with pitches that have no height.
Since we have many routes with height 0, probably making this field nullable is ok.

Test by opening Paklenica crag.

closes #76 