### PR TITLE
Search optional entities

### DIFF
--- a/src/crags/resolvers/search.resolver.ts
+++ b/src/crags/resolvers/search.resolver.ts
@@ -1,5 +1,6 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Query, Resolver } from '@nestjs/graphql';
+import { Args, Info, Query, Resolver } from '@nestjs/graphql';
+import { GraphQLResolveInfo } from 'graphql';
 import { AllowAny } from '../../auth/decorators/allow-any.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
@@ -18,11 +19,12 @@ export class SearchResolver {
   @UseGuards(UserAuthGuard)
   search(
     @CurrentUser() user: User,
+    @Info() gqlInfo: GraphQLResolveInfo,
     @Args('input', { nullable: true }) input?: string,
   ): Promise<SearchResults> {
     const cragsInput = new FindCragsInput();
     cragsInput.minStatus = user != null ? CragStatus.HIDDEN : CragStatus.PUBLIC;
 
-    return this.searchService.find(input, cragsInput);
+    return this.searchService.find(input, cragsInput, gqlInfo);
   }
 }

--- a/src/crags/utils/search-results.class.ts
+++ b/src/crags/utils/search-results.class.ts
@@ -7,18 +7,18 @@ import { User } from '../../users/entities/user.entity';
 
 @ObjectType()
 export class SearchResults {
-  @Field(() => [Crag])
-  crags: Crag[];
+  @Field(() => [Crag], { nullable: true })
+  crags?: Crag[];
 
-  @Field(() => [Route])
-  routes: Route[];
+  @Field(() => [Route], { nullable: true })
+  routes?: Route[];
 
-  @Field(() => [Sector])
-  sectors: Sector[];
+  @Field(() => [Sector], { nullable: true })
+  sectors?: Sector[];
 
-  @Field(() => [Comment])
-  comments: Comment[];
+  @Field(() => [Comment], { nullable: true })
+  comments?: Comment[];
 
-  @Field(() => [User])
-  users: User[];
+  @Field(() => [User], { nullable: true })
+  users?: User[];
 }


### PR DESCRIPTION
When calling a graphql search query  the service now performs the search only on entities that are requested by the query. 

To test this, execute various search queries through firecamp.

