### PR TITLE
Impossible logs fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "returns|type|of" }]
   },
 };

--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -38,6 +38,13 @@ export const tickAscentTypes = [
   AscentType.REPEAT,
 ];
 
+export const trTickAscentTypes = [
+  AscentType.T_ONSIGHT,
+  AscentType.T_FLASH,
+  AscentType.T_REDPOINT,
+  AscentType.T_REPEAT,
+];
+
 export enum PublishType {
   PUBLIC = 'public',
   CLUB = 'club',

--- a/src/activities/services/activities.service.ts
+++ b/src/activities/services/activities.service.ts
@@ -49,17 +49,15 @@ export class ActivitiesService {
       }
       queryRunner.manager.save(activity);
 
-      // Create activity-route for each route belonging to this activity
-      await Promise.all(
-        routesIn.map(async route => {
-          await this.activityRoutesService.create(
-            queryRunner,
-            route,
-            user,
-            activity,
-          );
-        }),
-      );
+      // Create activity-route for each route belonging to this activity. Process them in sequential order because one can log a single route more than once in a single post, and should take that into account when validating the logs
+      for (const routeIn of routesIn) {
+        await this.activityRoutesService.create(
+          queryRunner,
+          routeIn,
+          user,
+          activity,
+        );
+      }
 
       await queryRunner.commitTransaction();
       return activity;

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -145,6 +145,14 @@ export class ActivityRoutesService {
         return false;
     }
 
+    // a route cannot be repeated if it hasn't been previously ticked
+    if (
+      !routeTicked &&
+      (ascentType === AscentType.REPEAT || ascentType === AscentType.T_REPEAT)
+    ) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
1.
Logs of type 'repeat' are rejected if a logged route has not been ticked before.

Test by trying to log a route which you haven't ticked and choose repeat for ascentType.

2.
Logging same route multiple times within one log should enforce same restrictions as if each route was logged in its own log. 

Test by trying to log some impossible sequence of same route within one log.


Test through firecamp or through FE if corresponding PR on web has not been merged yet.
Test with plezanje-net/web#202
If testing wit above web PR the easiest way to test this is to make logPossible method of ArtivityFormService always return true (this will in effect disable impossible log checks on FE).
