### PR TITLE
Dataloading route type and grading system

### DIFF
--- a/src/crags/crags.module.ts
+++ b/src/crags/crags.module.ts
@@ -48,6 +48,9 @@ import { IceFallsResolver } from './resolvers/ice-falls.resolver';
 import { IceFallsService } from './services/ice-falls.service';
 import { PeaksService } from './services/peaks.service';
 import { PeaksResolver } from './resolvers/peaks.resolver';
+import { GradingSystemLoader } from './loaders/grading-system.loader';
+import { RouteTypesService } from './services/route-types.service';
+import { RouteTypeLoader } from './loaders/route-type.loader';
 
 @Module({
   imports: [
@@ -92,6 +95,8 @@ import { PeaksResolver } from './resolvers/peaks.resolver';
     RouteCommentsLoader,
     RoutePitchesLoader,
     SectorRoutesLoader,
+    GradingSystemLoader,
+    RouteTypeLoader,
     {
       provide: APP_INTERCEPTOR,
       useClass: DataLoaderInterceptor,
@@ -103,6 +108,7 @@ import { PeaksResolver } from './resolvers/peaks.resolver';
     IceFallsService,
     PeaksResolver,
     PeaksService,
+    RouteTypesService,
   ],
 })
 export class CragsModule {}

--- a/src/crags/loaders/grading-system.loader.ts
+++ b/src/crags/loaders/grading-system.loader.ts
@@ -1,0 +1,27 @@
+import DataLoader from 'dataloader';
+import { Injectable } from '@nestjs/common';
+import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
+import { GradingSystem } from '../entities/grading-system.entity';
+import { GradingSystemsService } from '../services/grading-systems.service';
+
+@Injectable()
+export class GradingSystemLoader
+  implements NestDataLoader<string, GradingSystem> {
+  constructor(private readonly gradingSystemsService: GradingSystemsService) {}
+
+  generateDataLoader(): DataLoader<string, GradingSystem> {
+    return new DataLoader<string, GradingSystem>(async keys => {
+      const gradingSystems = await this.gradingSystemsService.find();
+
+      const gradingSystemMap: { [key: string]: GradingSystem } = {};
+
+      gradingSystems.forEach(gradingSystem => {
+        gradingSystemMap[gradingSystem.id] = gradingSystem;
+      });
+
+      return keys.map(
+        gradingSystemId => gradingSystemMap[gradingSystemId] ?? null,
+      );
+    });
+  }
+}

--- a/src/crags/loaders/route-type.loader.ts
+++ b/src/crags/loaders/route-type.loader.ts
@@ -1,0 +1,24 @@
+import DataLoader from 'dataloader';
+import { Injectable } from '@nestjs/common';
+import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
+import { RouteTypesService } from '../services/route-types.service';
+import { RouteType } from '../entities/route-type.entity';
+
+@Injectable()
+export class RouteTypeLoader implements NestDataLoader<string, RouteType> {
+  constructor(private readonly routeTypesService: RouteTypesService) {}
+
+  generateDataLoader(): DataLoader<string, RouteType> {
+    return new DataLoader<string, RouteType>(async keys => {
+      const routeTypes = await this.routeTypesService.find();
+
+      const routeTypeMap: { [key: string]: RouteType } = {};
+
+      routeTypes.forEach(routeType => {
+        routeTypeMap[routeType.id] = routeType;
+      });
+
+      return keys.map(routeTypeId => routeTypeMap[routeTypeId] ?? null);
+    });
+  }
+}

--- a/src/crags/resolvers/crags.resolver.ts
+++ b/src/crags/resolvers/crags.resolver.ts
@@ -23,6 +23,12 @@ import { PopularCrag } from '../utils/popular-crag.class';
 import { MinCragStatus } from '../decorators/min-crag-status.decorator';
 import { AllowAny } from '../../auth/decorators/allow-any.decorator';
 import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
+import { GradingSystem } from '../entities/grading-system.entity';
+import { RouteType } from '../entities/route-type.entity';
+import { RouteTypeLoader } from '../loaders/route-type.loader';
+import { GradingSystemLoader } from '../loaders/grading-system.loader';
+import { Loader } from '../../core/interceptors/data-loader.interceptor';
+import DataLoader from 'dataloader';
 
 @Resolver(() => Crag)
 export class CragsResolver {
@@ -95,6 +101,15 @@ export class CragsResolver {
   @ResolveField('sectors', () => [Sector])
   async getSectors(@Parent() crag: Crag): Promise<Sector[]> {
     return this.sectorsService.findByCrag(crag.id);
+  }
+
+  @ResolveField('defaultGradingSystem', () => GradingSystem)
+  async defaultGradingSystem(
+    @Parent() crag: Crag,
+    @Loader(GradingSystemLoader)
+    loader: DataLoader<GradingSystem['id'], GradingSystem>,
+  ): Promise<GradingSystem> {
+    return loader.load(crag.defaultGradingSystemId);
   }
 
   @ResolveField('comments', () => [Comment])

--- a/src/crags/resolvers/routes.resolver.ts
+++ b/src/crags/resolvers/routes.resolver.ts
@@ -29,6 +29,10 @@ import { CragStatus } from '../entities/crag.entity';
 import { AllowAny } from '../../auth/decorators/allow-any.decorator';
 import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
 import { ForeignKeyConstraintFilter } from '../filters/foreign-key-constraint.filter';
+import { GradingSystem } from '../entities/grading-system.entity';
+import { GradingSystemLoader } from '../loaders/grading-system.loader';
+import { RouteType } from '../entities/route-type.entity';
+import { RouteTypeLoader } from '../loaders/route-type.loader';
 
 @Resolver(() => Route)
 export class RoutesResolver {
@@ -117,5 +121,23 @@ export class RoutesResolver {
     loader: DataLoader<Pitch['id'], Pitch[]>,
   ): Promise<Pitch[]> {
     return loader.load(route.id);
+  }
+
+  @ResolveField('defaultGradingSystem', () => GradingSystem)
+  async defaultGradingSystem(
+    @Parent() route: Route,
+    @Loader(GradingSystemLoader)
+    loader: DataLoader<GradingSystem['id'], GradingSystem>,
+  ): Promise<GradingSystem> {
+    return loader.load(route.defaultGradingSystemId);
+  }
+
+  @ResolveField('routeType', () => RouteType)
+  async routeType(
+    @Parent() route: Route,
+    @Loader(RouteTypeLoader)
+    loader: DataLoader<RouteType['id'], RouteType>,
+  ): Promise<RouteType> {
+    return loader.load(route.routeTypeId);
   }
 }

--- a/src/crags/services/route-types.service.spec.ts
+++ b/src/crags/services/route-types.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RouteTypesService } from './route-types.service';
+
+describe('RouteTypesService', () => {
+  let service: RouteTypesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RouteTypesService],
+    }).compile();
+
+    service = module.get<RouteTypesService>(RouteTypesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/crags/services/route-types.service.ts
+++ b/src/crags/services/route-types.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RouteType } from '../entities/route-type.entity';
+
+@Injectable()
+export class RouteTypesService {
+  constructor(
+    @InjectRepository(RouteType)
+    private routeTypeRepository: Repository<RouteType>,
+  ) {}
+
+  async find(): Promise<RouteType[]> {
+    return this.routeTypeRepository
+      .createQueryBuilder('routeType')
+      .orderBy({ 'routeType.position': 'ASC' })
+      .getMany();
+  }
+}


### PR DESCRIPTION
This should significantly boost crag loading performance.

Try to load kotecnik via firebase before and after.. for me it's 3s -> 700ms on local

query:
```
{
  __typename
  cragBySlug(slug: "kotecnik") {
    id
    slug
    name
    type
    orientation
    lat
    lon
    access
    description
    activityByMonth
    peak {
      name
      slug
      __typename
    }
    area {
      id
      name
      __typename
    }
    country {
      id
      name
      slug
      __typename
    }
    sectors {
      id
      name
      label
      routes {
        id
        name
        slug
        difficulty
        defaultGradingSystem {
          id
          __typename
        }
        isProject
        length
        routeType {
          id
          __typename
        }
        comments {
          id
          __typename
        }
        pitches {
          difficulty
          isProject
          number
          height
          __typename
        }
        __typename
      }
      bouldersOnly
      __typename
    }
    comments {
      id
      content
      created
      updated
      type
      exposedUntil
      user {
        id
        fullName
        __typename
      }
      __typename
    }
    images {
      id
      title
      path
      __typename
    }
    __typename
  }
}

```