### PR TITLE
Star rating

### DIFF
--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -15,6 +15,7 @@ import { ClubMember } from '../users/entities/club-member.entity';
 import { Club } from '../users/entities/club.entity';
 import { DifficultyVote } from '../crags/entities/difficulty-vote.entity';
 import { ActivityLoader } from './loaders/activity.loader';
+import { StarRatingVote } from '../crags/entities/star-rating-vote.entity';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ActivityLoader } from './loaders/activity.loader';
       ClubMember,
       Club,
       DifficultyVote,
+      StarRatingVote,
     ]),
     AuditModule,
     UsersModule,

--- a/src/activities/dtos/create-activity-route.input.ts
+++ b/src/activities/dtos/create-activity-route.input.ts
@@ -32,7 +32,7 @@ export class CreateActivityRouteInput {
   @IsOptional()
   votedDifficulty: number;
 
-  @Field({ nullable: true })
+  @Field(type => Int, { nullable: true })
   @IsOptional()
-  stars: number;
+  votedStarRating: number;
 }

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -105,7 +105,7 @@ export class ActivityRoutesService {
     }
 
     // if a vote on star rating (route beauty) is passed add a new star rating vote or update existing one
-    if (routeIn.votedStarRating) {
+    if (routeIn.votedStarRating !== null) {
       // but first check if a user even can vote (can vote only if the log is a tick)
       if (!tickAscentTypes.some(at => at === routeIn.ascentType)) {
         throw new HttpException(
@@ -127,8 +127,6 @@ export class ActivityRoutesService {
 
       await queryRunner.manager.save(starRatingVote);
     }
-
-    console.log(routeIn);
 
     if (activity !== null) {
       activityRoute.activity = Promise.resolve(activity);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,7 @@ import { Peak } from './crags/entities/peak.entity';
 import { IceFall } from './crags/entities/ice-fall.entity';
 import { Club } from './users/entities/club.entity';
 import { ClubMember } from './users/entities/club-member.entity';
-import { Rating } from './crags/entities/rating.entity';
+import { StarRatingVote } from './crags/entities/star-rating-vote.entity';
 import { userLoader } from './crags/loaders/user.loader';
 import { RouteType } from './crags/entities/route-type.entity';
 import { GradingSystem } from './crags/entities/grading-system.entity';
@@ -76,7 +76,7 @@ import { RouteEvent } from './crags/entities/route-event.entity';
           ClubMember,
           Image,
           IceFall,
-          Rating,
+          StarRatingVote,
           RouteType,
           RouteEvent,
           GradingSystem,

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -16,7 +16,7 @@ import { Comment } from './comment.entity';
 import { Pitch } from './pitch.entity';
 import { Image } from './image.entity';
 import { Crag } from './crag.entity';
-import { Rating } from './rating.entity';
+import { StarRatingVote } from './star-rating-vote.entity';
 import { GradingSystem } from './grading-system.entity';
 import { RouteType } from './route-type.entity';
 import { RouteEvent } from './route-event.entity';
@@ -129,12 +129,12 @@ export class Route extends BaseEntity {
   difficultyVotes: Promise<DifficultyVote[]>;
 
   @OneToMany(
-    () => Rating,
-    rating => rating.route,
+    () => StarRatingVote,
+    starRatingVote => starRatingVote.route,
     { nullable: true },
   )
-  @Field(() => [Rating])
-  ratings: Promise<Rating[]>;
+  @Field(type => [StarRatingVote])
+  starRatingVotes: Promise<StarRatingVote[]>;
 
   @OneToMany(
     () => Pitch,

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -67,6 +67,10 @@ export class Route extends BaseEntity {
   @Column()
   defaultGradingSystemId: string;
 
+  @Column({ type: 'float', nullable: true })
+  @Field({ nullable: true })
+  starRating: number;
+
   @Column({ type: 'int', nullable: true })
   @Field({ nullable: true })
   length: string;

--- a/src/crags/entities/star-rating-vote.entity.ts
+++ b/src/crags/entities/star-rating-vote.entity.ts
@@ -13,7 +13,7 @@ import { Route } from './route.entity';
 
 @Entity()
 @ObjectType()
-export class Rating extends BaseEntity {
+export class StarRatingVote extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   @Field()
   id: string;
@@ -36,9 +36,9 @@ export class Rating extends BaseEntity {
 
   @ManyToOne(
     () => Route,
-    route => route.ratings,
+    route => route.starRatingVotes,
     { onDelete: 'CASCADE' },
   )
-  @Field(() => Route)
+  @Field(type => Route)
   route: Promise<Route>;
 }

--- a/src/migration/1647767308908-convertRatingEntityToStarRatingVote.ts
+++ b/src/migration/1647767308908-convertRatingEntityToStarRatingVote.ts
@@ -1,0 +1,88 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class convertRatingEntityToStarRatingVote1647767308908
+  implements MigrationInterface {
+  name = 'convertRatingEntityToStarRatingVote1647767308908';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create new table with more suitable name
+    await queryRunner.query(
+      `CREATE TABLE "star_rating_vote" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "stars" integer NOT NULL, "created" TIMESTAMP NOT NULL DEFAULT now(), "updated" TIMESTAMP NOT NULL DEFAULT now(), "userId" uuid, "routeId" uuid, CONSTRAINT "PK_4752d18faaa38cf237fcfaa9843" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "star_rating_vote" ADD CONSTRAINT "FK_8e9d40091ce33caabaf43da8950" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "star_rating_vote" ADD CONSTRAINT "FK_59cdf2bf94368127c5f8b6096ee" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+
+    // Drop old table named rating
+    await queryRunner.query(`DROP TABLE "rating"`);
+
+    // Modify trigger function, that used the old table
+    // Also rename this function, so actually drop the old one, create new one, then also drop and recreate the trigger
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS delete_difficulty_and_beauty_vote ON activity_route;`,
+    );
+
+    await queryRunner.query(
+      `DROP FUNCTION delete_difficulty_and_beauty_vote();`,
+    );
+
+    await queryRunner.query(`
+        -- if deleted was the only tick of a route then automatically delete users difficulty vote for this route and users beauty (star rating) vote for this route
+
+        CREATE OR REPLACE FUNCTION delete_difficulty_and_star_rating_votes()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS
+        $$
+        DECLARE
+            numTicksLeft INTEGER;
+        BEGIN            
+            -- see if user has any ticks of this route left
+            SELECT count(*) INTO numTicksLeft FROM activity_route
+            WHERE "routeId" = OLD."routeId"
+            AND "userId" = OLD."userId"
+            AND "ascentType" IN ('redpoint', 'flash', 'onsight', 'repeat');
+
+            -- if this was not the last tick, no need to do anything
+            IF (numTicksLeft > 0) THEN
+                RETURN NULL;
+            END IF;
+
+            -- delete users difficulty vote for this route
+            DELETE FROM difficulty_vote
+            WHERE "userId" = OLD."userId"
+            AND "routeId" = OLD."routeId";
+
+            -- delete users star rating (beauty) vote for this route
+            DELETE FROM star_rating_vote
+            WHERE "userId" = OLD."userId"
+            AND "routeId" = OLD."routeId";
+
+            RETURN NULL;
+        END
+        $$;
+    `);
+
+    await queryRunner.query(`        
+        DROP TRIGGER IF EXISTS delete_difficulty_and_star_rating_votes ON activity_route;
+        CREATE TRIGGER delete_difficulty_and_star_rating_votes
+            AFTER DELETE
+            ON activity_route
+            FOR EACH ROW
+            EXECUTE PROCEDURE delete_difficulty_and_star_rating_votes();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "star_rating_vote" DROP CONSTRAINT "FK_59cdf2bf94368127c5f8b6096ee"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "star_rating_vote" DROP CONSTRAINT "FK_8e9d40091ce33caabaf43da8950"`,
+    );
+    await queryRunner.query(`DROP TABLE "star_rating_vote"`);
+  }
+}

--- a/src/migration/1647770003610-addStarRatingToRouteEntity.ts
+++ b/src/migration/1647770003610-addStarRatingToRouteEntity.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addStarRatingToRouteEntity1647770003610
+  implements MigrationInterface {
+  name = 'addStarRatingToRouteEntity1647770003610';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "route" ADD "starRating" double precision`,
+    );
+
+    // Create trigger to recalculate route's star rating every time a star rating vote is cast
+    await queryRunner.query(`
+        -- recalculates route's star rating from all star rating votes for this route
+        CREATE OR REPLACE FUNCTION recalculate_route_star_rating()
+            RETURNS TRIGGER
+            LANGUAGE PLPGSQL
+            AS
+        $$
+        BEGIN
+            UPDATE route
+            SET "starRating" = (
+                SELECT AVG(stars)
+                FROM star_rating_vote
+                WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId")
+            )
+            WHERE id = COALESCE(NEW."routeId", OLD."routeId");
+        
+            RETURN NEW;
+        END;
+        $$;
+    `);
+
+    await queryRunner.query(`
+        -- adds trigger to recalculate routes star rating when a vote is added, updated or removed
+        DROP TRIGGER IF EXISTS route_star_rating_vote ON star_rating_vote;
+        CREATE TRIGGER route_star_rating_vote
+        AFTER INSERT OR UPDATE OR DELETE
+        ON star_rating_vote
+        FOR EACH ROW
+        EXECUTE PROCEDURE recalculate_route_star_rating();
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "route" DROP COLUMN "starRating"`);
+    await queryRunner.query(
+      `DROP TRIGGER IF EXISTS route_star_rating_vote ON star_rating_vote;`,
+    );
+    await queryRunner.query(`DROP FUNCTION recalculate_route_star_rating()`);
+  }
+}


### PR DESCRIPTION
Backend now handles star rating votes. 

Entity rating was renamed to starRatingVote
A starRating field was added to Route entity

Db trigger was added that recalculates the star rating for a route every time a vote is added.

To test this log some routes with different accounts and observe the db table star_rating_vote and route table (field star_rating).
You can do so via firecamp or with plezanje-net/web#265

Do not forget to run typeorm migrations.

closes #80 
closes #86 
