### PR TITLE
Collate when ordering crags

### DIFF
--- a/src/crags/services/crags.service.ts
+++ b/src/crags/services/crags.service.ts
@@ -87,7 +87,7 @@ export class CragsService {
   private buildQuery(params: FindCragsInput = {}): SelectQueryBuilder<Crag> {
     const builder = this.cragsRepository.createQueryBuilder('c');
 
-    builder.orderBy('c.name', 'ASC');
+    builder.orderBy('c.name COLLATE "utf8_slovenian_ci"', 'ASC');
 
     if (params.country != null) {
       builder.andWhere('c.country = :countryId', {


### PR DESCRIPTION
closes #99 

To test, see the crag list, and note that S and Š crags are not mixed together.

![Screenshot 2022-04-02 at 12 53 34](https://user-images.githubusercontent.com/19568230/161379986-b10ae217-8708-4d03-9082-8647eff94049.png)
 