### PR TITLE
Make difficulty vote mandatory if a project is being ticked.

### DIFF
--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -131,6 +131,17 @@ export class ActivityRoutesService {
 
     activityRoute.route = Promise.resolve(route);
 
+    if (
+      route.isProject &&
+      this.isTick(routeIn.ascentType) &&
+      !routeIn.votedDifficulty
+    ) {
+      throw new HttpException(
+        'If ticking a project difficulty vote is required.',
+        HttpStatus.NOT_ACCEPTABLE,
+      );
+    }
+
     // if a vote on difficulty is passed add a new difficulty vote or update existing
     if (routeIn.votedDifficulty) {
       // but first check if a user even can vote (can vote only if the log is a tick)


### PR DESCRIPTION
There was no backend validaton for this. 

You can test the bug first, either through firecamp or before merging https://github.com/plezanje-net/web/pull/337

Start logging a project, set difficulty vote to some grade, switch to private publish type and see that the diff gets reset and disabled and the form becomes valid (although it shouldn't). Post the form.

After this PR BE should return error and log should fail.

