### PR TITLE
Recalculate difficulties of all routes.

### DIFF
--- a/src/migration/1650795167054-fixDiffVoteUntriggeredUpdates.ts
+++ b/src/migration/1650795167054-fixDiffVoteUntriggeredUpdates.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class fixDiffVoteUntriggeredUpdates1650795167054
+  implements MigrationInterface {
+  name = 'fixDiffVoteUntriggeredUpdates1650795167054';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // This dummy query will 'touch' every difficulty vote, effectivelly recalculating all routes' difficulties.
+    await queryRunner.query(
+      `UPDATE difficulty_vote SET difficulty = difficulty`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    return null;
+  }
+}


### PR DESCRIPTION
This runs a dummy query that does recalculation for every difficulty vote. 
It takes quite a long time (around 7min on my local machine)...
It makes sense to run it **after** https://github.com/plezanje-net/api/pull/107 is merged and deployed.

Tests with current db copied to local show that only 13 routes need diffs recalculated, so might be better to first merge and deploy https://github.com/plezanje-net/api/pull/107 and then manually trigger the difficulty recalculations on live db only for these few routes.