### PR TITLE
Route ascents count

### DIFF
--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -40,6 +40,5 @@ import { StarRatingVote } from '../crags/entities/star-rating-vote.entity';
     ActivityRoutesService,
     ActivityLoader,
   ],
-  exports: [ActivityRoutesService],
 })
 export class ActivitiesModule {}

--- a/src/activities/activities.module.ts
+++ b/src/activities/activities.module.ts
@@ -40,5 +40,6 @@ import { StarRatingVote } from '../crags/entities/star-rating-vote.entity';
     ActivityRoutesService,
     ActivityLoader,
   ],
+  exports: [ActivityRoutesService],
 })
 export class ActivitiesModule {}

--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -96,13 +96,11 @@ export class ActivityRoute extends BaseEntity {
   @Column({ nullable: true })
   activityId: string;
 
-  // TODO: why is this many to one relation. One activity route always has only one route
-  // TODO: and why is it nullable. Activity-route without a route makes no sense
-  @ManyToOne(() => Route, { nullable: true })
+  @ManyToOne(() => Route)
   @Field(() => Route)
   route: Promise<Route>;
-  @Column({ nullable: true })
-  @Field({ nullable: true })
+  @Column()
+  @Field()
   routeId: string;
 
   @ManyToOne(() => Pitch, { nullable: true })

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -785,29 +785,4 @@ export class ActivityRoutesService {
   async delete(activityRoute: ActivityRoute): Promise<boolean> {
     return this.activityRoutesRepository.remove(activityRoute).then(() => true);
   }
-
-  countTicks(route: Route) {
-    return this.activityRoutesRepository.count({
-      where: {
-        routeId: route.id,
-        ascentType: In([...tickAscentTypes]),
-      },
-    });
-  }
-
-  countTries(route: Route) {
-    return this.activityRoutesRepository.count({
-      where: { routeId: route.id },
-    });
-  }
-
-  async countDisctinctClimbers(route: Route) {
-    const result = this.activityRoutesRepository
-      .createQueryBuilder('ar')
-      .select('COUNT(DISTINCT(ar."userId")) as "nrClimbers"')
-      .where('ar.routeId = :routeId', { routeId: route.id })
-      .getRawOne();
-
-    return (await result).nrClimbers;
-  }
 }

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -176,14 +176,6 @@ export class ActivityRoutesService {
 
     // if a vote on star rating (route beauty) is passed add a new star rating vote or update existing one
     if (routeIn.votedStarRating || routeIn.votedStarRating === 0) {
-      // but first check if a user even can vote (can vote only if the log is a tick)
-      if (!this.isTick(routeIn.ascentType)) {
-        throw new HttpException(
-          'Cannot vote on star rating (beauty) if not logging a tick.',
-          HttpStatus.NOT_ACCEPTABLE,
-        );
-      }
-
       let starRatingVote = await queryRunner.manager.findOne(StarRatingVote, {
         user,
         route,

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -10,6 +10,7 @@ import { Club } from '../../users/entities/club.entity';
 import { User } from '../../users/entities/user.entity';
 import {
   Connection,
+  In,
   QueryRunner,
   Repository,
   SelectQueryBuilder,
@@ -783,5 +784,30 @@ export class ActivityRoutesService {
 
   async delete(activityRoute: ActivityRoute): Promise<boolean> {
     return this.activityRoutesRepository.remove(activityRoute).then(() => true);
+  }
+
+  countTicks(route: Route) {
+    return this.activityRoutesRepository.count({
+      where: {
+        routeId: route.id,
+        ascentType: In([...tickAscentTypes]),
+      },
+    });
+  }
+
+  countTries(route: Route) {
+    return this.activityRoutesRepository.count({
+      where: { routeId: route.id },
+    });
+  }
+
+  async countDisctinctClimbers(route: Route) {
+    const result = this.activityRoutesRepository
+      .createQueryBuilder('ar')
+      .select('COUNT(DISTINCT(ar."userId")) as "nrClimbers"')
+      .where('ar.routeId = :routeId', { routeId: route.id })
+      .getRawOne();
+
+    return (await result).nrClimbers;
   }
 }

--- a/src/core/interfaces/order-by-input.interface.ts
+++ b/src/core/interfaces/order-by-input.interface.ts
@@ -6,7 +6,7 @@ export class OrderByInput {
   @Field()
   field: string;
 
-  @Field(() => String)
+  @Field(() => String, { nullable: true })
   @IsOptional()
   direction?: 'ASC' | 'DESC';
 }

--- a/src/crags/crags.module.ts
+++ b/src/crags/crags.module.ts
@@ -58,6 +58,7 @@ import { RouteProperty } from './entities/route-property.entity';
 import { CragProperty } from './entities/crag-property.entity';
 import { IceFallProperty } from './entities/ice-fall-property.entity';
 import { EntityPropertiesService } from './services/entity-properties.service';
+import { ActivitiesModule } from '../activities/activities.module';
 
 @Module({
   imports: [
@@ -82,6 +83,7 @@ import { EntityPropertiesService } from './services/entity-properties.service';
       IceFallProperty,
     ]),
     AuditModule,
+    ActivitiesModule,
   ],
   providers: [
     CragsResolver,

--- a/src/crags/crags.module.ts
+++ b/src/crags/crags.module.ts
@@ -58,7 +58,9 @@ import { RouteProperty } from './entities/route-property.entity';
 import { CragProperty } from './entities/crag-property.entity';
 import { IceFallProperty } from './entities/ice-fall-property.entity';
 import { EntityPropertiesService } from './services/entity-properties.service';
-import { ActivitiesModule } from '../activities/activities.module';
+import { RouteNrTicksLoader } from './loaders/route-nr-ticks.loader';
+import { RouteNrTriesLoader } from './loaders/route-nr-tries.loader';
+import { RouteNrClimbersLoader } from './loaders/route-nr-climbers.loader';
 
 @Module({
   imports: [
@@ -83,7 +85,6 @@ import { ActivitiesModule } from '../activities/activities.module';
       IceFallProperty,
     ]),
     AuditModule,
-    ActivitiesModule,
   ],
   providers: [
     CragsResolver,
@@ -111,6 +112,9 @@ import { ActivitiesModule } from '../activities/activities.module';
     RouteTypeLoader,
     CountryLoader,
     RouteLoader,
+    RouteNrTicksLoader,
+    RouteNrTriesLoader,
+    RouteNrClimbersLoader,
     CragLoader,
     {
       provide: APP_INTERCEPTOR,

--- a/src/crags/dtos/create-route.input.ts
+++ b/src/crags/dtos/create-route.input.ts
@@ -9,7 +9,7 @@ export class CreateRouteInput {
 
   @Field({ nullable: true })
   @IsOptional()
-  length: string;
+  length: number;
 
   @Field({ nullable: true })
   @IsOptional()

--- a/src/crags/dtos/update-route.input.ts
+++ b/src/crags/dtos/update-route.input.ts
@@ -13,7 +13,7 @@ export class UpdateRouteInput {
 
   @Field({ nullable: true })
   @IsOptional()
-  length: string;
+  length: number;
 
   @Field({ nullable: true })
   @IsOptional()

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -188,5 +188,14 @@ export class Route extends BaseEntity {
     () => ActivityRoute,
     activityRoute => activityRoute.route,
   )
-  activityRoute: ActivityRoute[];
+  activityRoutes: ActivityRoute[];
+
+  @Field()
+  nrTicks: number;
+
+  @Field()
+  nrTries: number;
+
+  @Field()
+  nrClimbers: number;
 }

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -77,7 +77,7 @@ export class Route extends BaseEntity {
 
   @Column({ type: 'int', nullable: true })
   @Field({ nullable: true })
-  length: string;
+  length: number;
 
   @Column({ nullable: true })
   @Field({ nullable: true })

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -23,6 +23,7 @@ import { GradingSystem } from './grading-system.entity';
 import { RouteType } from './route-type.entity';
 import { RouteEvent } from './route-event.entity';
 import { Book } from './book.entity';
+import { ActivityRoute } from '../../activities/entities/activity-route.entity';
 
 export enum RouteStatus {
   PUBLIC = 'public',
@@ -182,4 +183,10 @@ export class Route extends BaseEntity {
   @ManyToMany(() => Book)
   @JoinTable()
   books: Book[];
+
+  @OneToMany(
+    () => ActivityRoute,
+    activityRoute => activityRoute.route,
+  )
+  activityRoute: ActivityRoute[];
 }

--- a/src/crags/loaders/route-nr-climbers.loader.ts
+++ b/src/crags/loaders/route-nr-climbers.loader.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import DataLoader from 'dataloader';
+import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
+import { RoutesService } from '../services/routes.service';
+
+@Injectable()
+export class RouteNrClimbersLoader implements NestDataLoader<string, number> {
+  constructor(private readonly routesService: RoutesService) {}
+
+  generateDataLoader(): DataLoader<string, number> {
+    return new DataLoader<string, number>(async keys => {
+      const climbersCounts = await this.routesService.countManyDisctinctClimbers(
+        keys,
+      );
+
+      const climbersCountsMap = {};
+
+      climbersCounts.forEach(
+        climbersCount =>
+          (climbersCountsMap[climbersCount.r_id] = climbersCount.nrClimbers),
+      );
+
+      return keys.map(routeId => climbersCountsMap[routeId]);
+    });
+  }
+}

--- a/src/crags/loaders/route-nr-ticks.loader.ts
+++ b/src/crags/loaders/route-nr-ticks.loader.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import DataLoader from 'dataloader';
+import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
+import { RoutesService } from '../services/routes.service';
+
+@Injectable()
+export class RouteNrTicksLoader implements NestDataLoader<string, number> {
+  constructor(private readonly routesService: RoutesService) {}
+
+  generateDataLoader(): DataLoader<string, number> {
+    return new DataLoader<string, number>(async keys => {
+      const tickCounts = await this.routesService.countManyTicks(keys);
+
+      const tickCountsMap = {};
+
+      tickCounts.forEach(
+        tickCount => (tickCountsMap[tickCount.r_id] = tickCount.nrTicks),
+      );
+
+      return keys.map(routeId => tickCountsMap[routeId]);
+    });
+  }
+}

--- a/src/crags/loaders/route-nr-tries.loader.ts
+++ b/src/crags/loaders/route-nr-tries.loader.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import DataLoader from 'dataloader';
+import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
+import { RoutesService } from '../services/routes.service';
+
+@Injectable()
+export class RouteNrTriesLoader implements NestDataLoader<string, number> {
+  constructor(private readonly routesService: RoutesService) {}
+
+  generateDataLoader(): DataLoader<string, number> {
+    return new DataLoader<string, number>(async keys => {
+      const tryCounts = await this.routesService.countManyTries(keys);
+
+      const tryCountsMap = {};
+
+      tryCounts.forEach(
+        tryCount => (tryCountsMap[tryCount.r_id] = tryCount.nrTries),
+      );
+
+      return keys.map(routeId => tryCountsMap[routeId]);
+    });
+  }
+}

--- a/src/crags/resolvers/routes.resolver.ts
+++ b/src/crags/resolvers/routes.resolver.ts
@@ -36,15 +36,15 @@ import { RouteTypeLoader } from '../loaders/route-type.loader';
 import { CragLoader } from '../loaders/crag.loader';
 import { RouteProperty } from '../entities/route-property.entity';
 import { EntityPropertiesService } from '../services/entity-properties.service';
+import { ActivityRoutesService } from '../../activities/services/activity-routes.service';
 
 @Resolver(() => Route)
 export class RoutesResolver {
   constructor(
     private routesService: RoutesService,
-    private commentsService: CommentsService,
-    private pitchesService: PitchesService,
     private difficultyVotesService: DifficultyVotesService,
     private entityPropertiesService: EntityPropertiesService,
+    private activityRoutesService: ActivityRoutesService,
   ) {}
 
   @Mutation(() => Route)
@@ -157,5 +157,20 @@ export class RoutesResolver {
     loader: DataLoader<RouteType['id'], RouteType>,
   ): Promise<RouteType> {
     return loader.load(route.routeTypeId);
+  }
+
+  @ResolveField('nrTicks', returns => Number)
+  async nrTicks(@Parent() route: Route) {
+    return this.activityRoutesService.countTicks(route);
+  }
+
+  @ResolveField('nrTries', returns => Number)
+  async nrTries(@Parent() route: Route) {
+    return this.activityRoutesService.countTries(route);
+  }
+
+  @ResolveField('nrClimbers', returns => Number)
+  async nrClimbers(@Parent() route: Route) {
+    return this.activityRoutesService.countDisctinctClimbers(route);
   }
 }

--- a/src/crags/resolvers/routes.resolver.ts
+++ b/src/crags/resolvers/routes.resolver.ts
@@ -14,11 +14,9 @@ import { NotFoundFilter } from '../filters/not-found.filter';
 import { CreateRouteInput } from '../dtos/create-route.input';
 import { UpdateRouteInput } from '../dtos/update-route.input';
 import { RoutesService } from '../services/routes.service';
-import { CommentsService } from '../services/comments.service';
 import { Comment } from '../entities/comment.entity';
 import { DifficultyVote } from '../entities/difficulty-vote.entity';
 import { Pitch } from '../entities/pitch.entity';
-import { PitchesService } from '../services/pitches.service';
 import { RouteCommentsLoader } from '../loaders/route-comments.loader';
 import DataLoader from 'dataloader';
 import { Loader } from '../../core/interceptors/data-loader.interceptor';
@@ -36,7 +34,9 @@ import { RouteTypeLoader } from '../loaders/route-type.loader';
 import { CragLoader } from '../loaders/crag.loader';
 import { RouteProperty } from '../entities/route-property.entity';
 import { EntityPropertiesService } from '../services/entity-properties.service';
-import { ActivityRoutesService } from '../../activities/services/activity-routes.service';
+import { RouteNrTicksLoader } from '../loaders/route-nr-ticks.loader';
+import { RouteNrTriesLoader } from '../loaders/route-nr-tries.loader';
+import { RouteNrClimbersLoader } from '../loaders/route-nr-climbers.loader';
 
 @Resolver(() => Route)
 export class RoutesResolver {
@@ -44,7 +44,6 @@ export class RoutesResolver {
     private routesService: RoutesService,
     private difficultyVotesService: DifficultyVotesService,
     private entityPropertiesService: EntityPropertiesService,
-    private activityRoutesService: ActivityRoutesService,
   ) {}
 
   @Mutation(() => Route)
@@ -160,17 +159,26 @@ export class RoutesResolver {
   }
 
   @ResolveField('nrTicks', returns => Number)
-  async nrTicks(@Parent() route: Route) {
-    return this.activityRoutesService.countTicks(route);
+  async nrTicks(
+    @Parent() route: Route,
+    @Loader(RouteNrTicksLoader) loader: DataLoader<string, number>,
+  ) {
+    return loader.load(route.id);
   }
 
   @ResolveField('nrTries', returns => Number)
-  async nrTries(@Parent() route: Route) {
-    return this.activityRoutesService.countTries(route);
+  async nrTries(
+    @Parent() route: Route,
+    @Loader(RouteNrTriesLoader) loader: DataLoader<string, number>,
+  ) {
+    return loader.load(route.id);
   }
 
   @ResolveField('nrClimbers', returns => Number)
-  async nrClimbers(@Parent() route: Route) {
-    return this.activityRoutesService.countDisctinctClimbers(route);
+  async nrClimbers(
+    @Parent() route: Route,
+    @Loader(RouteNrClimbersLoader) loader: DataLoader<string, number>,
+  ) {
+    return loader.load(route.id);
   }
 }

--- a/src/crags/resolvers/sectors.resolver.ts
+++ b/src/crags/resolvers/sectors.resolver.ts
@@ -14,22 +14,17 @@ import { Sector } from '../entities/sector.entity';
 import { SectorsService } from '../services/sectors.service';
 import { CreateSectorInput } from '../dtos/create-sector.input';
 import { UpdateSectorInput } from '../dtos/update-sector.input';
-import { RoutesService } from '../services/routes.service';
 import { Route } from '../entities/route.entity';
 import { Loader } from '../../core/interceptors/data-loader.interceptor';
 import { SectorRoutesLoader } from '../loaders/sector-routes.loader';
 import DataLoader from 'dataloader';
 import { AllowAny } from '../../auth/decorators/allow-any.decorator';
 import { UserAuthGuard } from '../../auth/guards/user-auth.guard';
-import { MinCragStatus } from '../decorators/min-crag-status.decorator';
 import { ForeignKeyConstraintFilter } from '../filters/foreign-key-constraint.filter';
 
 @Resolver(() => Sector)
 export class SectorsResolver {
-  constructor(
-    private sectorsService: SectorsService,
-    private routesService: RoutesService,
-  ) {}
+  constructor(private sectorsService: SectorsService) {}
 
   @Query(() => Sector)
   @UseFilters(NotFoundFilter)

--- a/src/migration/1652439836973-activity-route-non-nullable.ts
+++ b/src/migration/1652439836973-activity-route-non-nullable.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class activityRouteNonNullable1652439836973
+  implements MigrationInterface {
+  name = 'activityRouteNonNullable1652439836973';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" DROP CONSTRAINT "FK_ebb17ba34f1d7783c1c146d062e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" ALTER COLUMN "routeId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" ADD CONSTRAINT "FK_ebb17ba34f1d7783c1c146d062e" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" DROP CONSTRAINT "FK_ebb17ba34f1d7783c1c146d062e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" ALTER COLUMN "routeId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "activity_route" ADD CONSTRAINT "FK_ebb17ba34f1d7783c1c146d062e" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}


### PR DESCRIPTION
Add field resolvers to get the following counts for a route:
- number of ticks (successful ascents)
- number of tries (all failed + successful ascents)
- number of climbers (distinct people that tried the route)

test through Firecamp and try to fetch these 3 properties on a route and/or test with https://github.com/plezanje-net/web/pull/362