### PR TITLE
Enable modifying base difficulty of a route.

### DIFF
--- a/src/crags/dtos/update-route.input.ts
+++ b/src/crags/dtos/update-route.input.ts
@@ -45,5 +45,13 @@ export class UpdateRouteInput {
 
   @Field({ nullable: true })
   @IsOptional()
+  baseDifficulty: number;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  isProject: boolean;
+
+  @Field({ nullable: true })
+  @IsOptional()
   rejectionMessage: string;
 }

--- a/src/crags/services/routes.service.ts
+++ b/src/crags/services/routes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { Route } from '../entities/route.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Sector } from '../entities/sector.entity';
@@ -28,12 +28,10 @@ export class RoutesService extends ContributablesService {
     @InjectRepository(Sector)
     protected sectorsRepository: Repository<Sector>,
     @InjectRepository(Crag)
-    protected cragRepository: Repository<Crag>,
-    @InjectRepository(DifficultyVote)
-    private difficultyVoteRepository: Repository<DifficultyVote>,
+    protected cragsRepository: Repository<Crag>,
     private connection: Connection,
   ) {
-    super(cragRepository, sectorsRepository, routesRepository);
+    super(cragsRepository, sectorsRepository, routesRepository);
   }
 
   async find(input: FindRoutesServiceInput): Promise<Route[]> {
@@ -132,7 +130,11 @@ export class RoutesService extends ContributablesService {
       await this.shiftFollowingRoutes(route, transaction);
 
       if (data.baseDifficulty != null && !route.isProject) {
-        await this.createBaseGrade(route, data.baseDifficulty, transaction);
+        await this.createBaseDifficulty(
+          route,
+          data.baseDifficulty,
+          transaction,
+        );
       }
       await this.updateUserContributionsFlag(
         route.publishStatus,
@@ -150,22 +152,79 @@ export class RoutesService extends ContributablesService {
   }
 
   async update(data: UpdateRouteInput): Promise<Route> {
-    const route = await this.routesRepository.findOneOrFail(data.id);
-
-    this.routesRepository.merge(route, data);
-
-    if (data.name != null) {
-      route.slug = await this.generateRouteSlug(
-        route.name,
-        route.cragId,
-        route.id,
-      );
-    }
-
     const transaction = new Transaction(this.connection);
     await transaction.start();
-
+    let route = await transaction.queryRunner.manager.findOneOrFail(
+      Route,
+      data.id,
+    );
     try {
+      // Is the request trying to update the route base difficulty?
+      if (
+        (data.baseDifficulty != undefined &&
+          data.baseDifficulty != route.difficulty) ||
+        (data.isProject != undefined && data.isProject != route.isProject)
+      ) {
+        // First check that route has no difficulty votes yet (except for the base difficulty vote)
+        if (await this.hasRealDifficultyVotes(route, transaction)) {
+          throw new HttpException(
+            'Cannot update base difficulty of route with existing difficulty votes',
+            HttpStatus.CONFLICT,
+          );
+        }
+
+        // Project and baseDifficulty mutually exclude each other
+        const isProjectAfterUpdate = data.isProject ?? route.isProject;
+        const baseDifficultyAfterUpdate =
+          data.baseDifficulty === undefined
+            ? route.difficulty
+            : data.baseDifficulty;
+        if (
+          (isProjectAfterUpdate && baseDifficultyAfterUpdate) ||
+          (!isProjectAfterUpdate && !baseDifficultyAfterUpdate)
+        ) {
+          throw new HttpException(
+            'Base difficulty is required for non-project routes or omitted for project routes',
+            HttpStatus.CONFLICT,
+          );
+        }
+
+        if (route.isProject && !isProjectAfterUpdate) {
+          // Route was a project and now is not. Base difficulty should be received and base difficulty vote should be created.
+          await this.createBaseDifficulty(
+            route,
+            data.baseDifficulty,
+            transaction,
+          );
+        } else if (!route.isProject && isProjectAfterUpdate) {
+          // Route was not a project and now is. Base difficulty should be deleted.
+          await this.deleteBaseDifficulty(route, transaction);
+        } else {
+          await this.updateBaseDifficulty(
+            route,
+            data.baseDifficulty,
+            transaction,
+          );
+        }
+
+        // Refetch route, because trigger should have changed the calculated difficulty
+        route = await transaction.queryRunner.manager.findOneOrFail(
+          Route,
+          data.id,
+        );
+      }
+
+      transaction.queryRunner.manager.merge(Route, route, data);
+
+      // TODO: this will always be true when posting from route popup in management. should probably update only if the name actually changed
+      if (data.name != null) {
+        route.slug = await this.generateRouteSlug(
+          route.name,
+          route.cragId,
+          route.id,
+        );
+      }
+
       await transaction.save(route);
       await this.shiftFollowingRoutes(route, transaction);
       const user = await route.user;
@@ -178,7 +237,6 @@ export class RoutesService extends ContributablesService {
       await transaction.rollback();
       throw e;
     }
-
     await transaction.commit();
 
     return Promise.resolve(route);
@@ -227,7 +285,7 @@ export class RoutesService extends ContributablesService {
     return Promise.resolve(true);
   }
 
-  private async createBaseGrade(
+  private async createBaseDifficulty(
     route: Route,
     difficulty: number,
     transaction: Transaction,
@@ -238,6 +296,40 @@ export class RoutesService extends ContributablesService {
     vote.isBase = true;
 
     return transaction.save(vote);
+  }
+
+  private async updateBaseDifficulty(
+    route: Route,
+    difficulty: number,
+    transaction: Transaction,
+  ): Promise<void> {
+    const difficultyVote = await transaction.queryRunner.manager.findOneOrFail(
+      DifficultyVote,
+      {
+        route,
+        isBase: true,
+      },
+    );
+    difficultyVote.difficulty = difficulty;
+    return transaction.save(difficultyVote);
+  }
+
+  private async deleteBaseDifficulty(route: Route, transaction: Transaction) {
+    const difficultyVote = await transaction.queryRunner.manager.findOneOrFail(
+      DifficultyVote,
+      {
+        route,
+        isBase: true,
+      },
+    );
+    return transaction.delete(difficultyVote);
+  }
+
+  private async hasRealDifficultyVotes(route: Route, transaction: Transaction) {
+    return transaction.queryRunner.manager.count(DifficultyVote, {
+      route,
+      isBase: false,
+    });
   }
 
   private buildQuery(


### PR DESCRIPTION
Enable updating base difficulty on routes that have no difficulty votes yet.

to test, try as many different scenarios as possible>
- route with ascents and diff votes (should be denied)
- route with ascents and no diff votes (should be denied)
- route with no ascents and diff votes, if you can find one (should be denied)
- project to graded route
- graded route to project
- change of grade
- invalid data (not project and no diff)
- invalid data (project and diff)
- updating other route data...
and so on...


test with: https://github.com/plezanje-net/web/pull/393
