### PR TITLE
Remove jwt expiration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -123,7 +123,9 @@ import { PropertyType } from './crags/entities/property-type.entity';
                 );
 
                 const user = await authService.validateJwtPayload(jwt);
-                return { roles: user.roles.map(role => role.role) };
+                if (user) {
+                  return { roles: user.roles.map(role => role.role) };
+                }
               }
             },
           }),

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -17,7 +17,6 @@ import { CacheControlService } from '../core/services/cache-control.service';
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get('JWT_SECRET'),
-        signOptions: { expiresIn: '30d' },
       }),
       inject: [ConfigService],
     }),

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -18,7 +18,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(configService: ConfigService, private authService: AuthService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      ignoreExpiration: false,
+      ignoreExpiration: true,
       secretOrKey: configService.get('JWT_SECRET'),
     });
   }

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -81,7 +81,9 @@ export class UsersService {
   }
 
   async recover(email: string): Promise<User> {
-    const user = await this.usersRepository.findOneOrFail({ email: email });
+    const user = await this.usersRepository.findOneOrFail({
+      email: email.toLowerCase(),
+    });
 
     user.passwordToken = randomBytes(20).toString('hex');
 


### PR DESCRIPTION
As we validate user against the database anyway, expiration is not needed in jwt token. This should take care of the problem, where FE considers users as logged in because local storage token expires in 1y while token itself has expiration set to 1 month.

closes https://github.com/plezanje-net/web/issues/367

To test that expiry is really ignored, you can set the expiry to 30s or so and login.. refresh after 30s and see that everything still works.

Will make another PR for frontend, where we log out the user if authentication fails for any reason other than token expiration

also added tolowercase conversion for issue https://github.com/plezanje-net/api/issues/117
closes https://github.com/plezanje-net/api/issues/117