### PR TITLE
Sort routes ascending in activity entry view

### DIFF
--- a/src/activities/resolvers/activities.resolver.ts
+++ b/src/activities/resolvers/activities.resolver.ts
@@ -183,6 +183,7 @@ export class ActivitiesResolver {
   @ResolveField('routes', () => [ActivityRoute])
   async getRoutes(@Parent() activity: Activity): Promise<ActivityRoute[]> {
     return this.activityRoutesService.find({
+      orderBy: { field: 'position', direction: 'ASC' },
       activityId: activity.id,
     });
   }

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -699,10 +699,12 @@ export class ActivityRoutesService {
         params.orderBy.direction || 'DESC',
       );
 
-      builder.addOrderBy(
-        'ar.position',
-        params.orderBy.field === 'date' ? params.orderBy.direction : 'DESC',
-      );
+      if (params.orderBy.field != 'position') {
+        builder.addOrderBy(
+          'ar.position',
+          params.orderBy.field === 'date' ? params.orderBy.direction : 'DESC',
+        );
+      }
     } else {
       builder.orderBy('ar.created', 'DESC').addOrderBy('ar.position', 'DESC');
     }


### PR DESCRIPTION
closes https://github.com/plezanje-net/web/issues/326

test by opening any activity and see that positions are chronological
see that ascent list stays sorted descending (both use the same service)

wrapped the addition of position sorting that is added to all queries in case position in case position is primary sort field