### PR TITLE
Fix upload images async and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --dataSource src/ormconfig.ts",
     "migration:run": "npm run typeorm migration:run",
     "migration:revert": "npm run typeorm migration:revert",
-    "migration:generate": "npm run typeorm migration:generate -- -n",
+    "migration:generate": "npm run typeorm migration:generate -n",
     "migration:create": "npm run typeorm migration:create -- -n",
     "migration:show": "npm run typeorm migration:show"
   },

--- a/src/crags/controllers/upload/upload.controller.ts
+++ b/src/crags/controllers/upload/upload.controller.ts
@@ -31,7 +31,7 @@ export class UploadController {
       throw new BadRequestException();
     }
 
-    return this.imagesService.createImage(
+    return await this.imagesService.createImage(
       uploadImageDto,
       imageFile,
       currentUser,

--- a/src/crags/dtos/upload-image.dto.ts
+++ b/src/crags/dtos/upload-image.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsEnum, IsNotEmpty } from 'class-validator';
 import { ImageParentEntityType } from '../entities/image.entity';
 
 export class UploadImageDto {

--- a/src/crags/dtos/upload-image.dto.ts
+++ b/src/crags/dtos/upload-image.dto.ts
@@ -1,5 +1,5 @@
 import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
-import { ImageParentEntityType, ImageType } from '../entities/image.entity';
+import { ImageParentEntityType } from '../entities/image.entity';
 
 export class UploadImageDto {
   @IsNotEmpty()
@@ -11,9 +11,8 @@ export class UploadImageDto {
 
   title?: string;
 
-  @IsOptional()
-  @IsEnum(ImageType)
-  type?: ImageType;
+  @IsNotEmpty()
+  author: string;
 
   description?: string;
 }

--- a/src/crags/entities/image.entity.ts
+++ b/src/crags/entities/image.entity.ts
@@ -16,13 +16,6 @@ import { Peak } from './peak.entity';
 import { IceFall } from './ice-fall.entity';
 import { User } from '../../users/entities/user.entity';
 
-export enum ImageType {
-  PHOTO = 'photo',
-  SKETCH = 'sketch',
-  MAP = 'map',
-  PROFILE = 'profile',
-}
-
 export enum ImageParentEntityType {
   CRAG = 'crag',
   ROUTE = 'route',
@@ -36,13 +29,6 @@ export class Image extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   @Field()
   id: string;
-
-  @Column({
-    type: 'enum',
-    enum: ImageType,
-    default: ImageType.PHOTO,
-  })
-  type: ImageType;
 
   @Column({ nullable: true })
   @Field({ nullable: true })
@@ -61,11 +47,11 @@ export class Image extends BaseEntity {
   extension: string;
 
   @Column({ type: 'float' })
-  @Field(type => Float)
+  @Field((type) => Float)
   aspectRatio: number;
 
   @Column({ type: 'integer' })
-  @Field(type => Int)
+  @Field((type) => Int)
   maxIntrinsicWidth: number;
 
   @CreateDateColumn()
@@ -74,61 +60,49 @@ export class Image extends BaseEntity {
   @UpdateDateColumn()
   updated: Date;
 
-  @ManyToOne(
-    () => User,
-    user => user.images,
-  )
+  // The user that contributed the image
+  @ManyToOne(() => User, (user) => user.images)
   @Field(() => User, { nullable: true })
   user: Promise<User>;
+
+  // The actual author of the photo/image
+  @Column({ nullable: true })
+  @Field({ nullable: true })
+  author: string;
 
   @Column({ nullable: true })
   legacy: string;
 
-  @ManyToOne(
-    () => Area,
-    area => area.images,
-    { nullable: true },
-  )
+  @ManyToOne(() => Area, (area) => area.images, { nullable: true })
   @Field(() => Area, { nullable: true })
   area: Promise<Area>;
 
-  @ManyToOne(
-    () => Crag,
-    crag => crag.images,
-    { nullable: true, onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Crag, (crag) => crag.images, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
   @Field(() => Crag, { nullable: true })
   crag: Promise<Crag>;
 
-  @ManyToOne(
-    () => Route,
-    route => route.images,
-    { nullable: true, onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Route, (route) => route.images, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
   @Field(() => Route, { nullable: true })
   route: Promise<Route>;
 
-  @ManyToOne(
-    () => IceFall,
-    iceFall => iceFall.images,
-    { nullable: true },
-  )
+  @ManyToOne(() => IceFall, (iceFall) => iceFall.images, { nullable: true })
   @Field(() => IceFall, { nullable: true })
   iceFall: Promise<IceFall>;
 
-  @ManyToOne(
-    () => Comment,
-    comment => comment.images,
-    { nullable: true, onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Comment, (comment) => comment.images, {
+    nullable: true,
+    onDelete: 'CASCADE',
+  })
   @Field(() => Comment, { nullable: true })
   comment: Promise<Comment>;
 
-  @ManyToOne(
-    () => Peak,
-    peak => peak.images,
-    { nullable: true },
-  )
+  @ManyToOne(() => Peak, (peak) => peak.images, { nullable: true })
   @Field(() => Peak, { nullable: true })
   peak: Promise<Peak>;
 }

--- a/src/crags/services/images.service.ts
+++ b/src/crags/services/images.service.ts
@@ -40,7 +40,6 @@ export class ImagesService {
       )
 
       .andWhere("r.publishStatus = 'published'") // only show ticks for published routes
-      .andWhere('i.type = :type', { type: 'photo' }) // Comment this out if you want to show all types of images
       .orderBy('i.created', 'DESC')
       .limit(latest);
 
@@ -56,7 +55,7 @@ export class ImagesService {
     imageFile: Express.Multer.File,
     currentUser: User,
   ) {
-    const { entityType, entityId, type, title, description } = uploadImageDto;
+    const { entityType, entityId, author, title, description } = uploadImageDto;
     const inputExtension = path.extname(imageFile.originalname);
 
     let crag: Crag;
@@ -93,6 +92,7 @@ export class ImagesService {
       extension: inputExtension,
       aspectRatio,
       maxIntrinsicWidth,
+      author,
       title,
       description,
     });

--- a/src/crags/services/images.service.ts
+++ b/src/crags/services/images.service.ts
@@ -105,7 +105,7 @@ export class ImagesService {
 
     await this.imagesRepository.save(image);
 
-    return image.id;
+    return image;
   }
 
   private async generateUniqueStem(entity: string, stemBase: string) {
@@ -138,35 +138,39 @@ export class ImagesService {
       .toFile(`${env.STORAGE_PATH}/images/${entity}s/${stem}${extension}`);
 
     // Generate all of the predefined sizes and save them as webp, avif and jpeg
-    this.targetSizes.forEach(async size => {
-      // Resize image (only if big enough)
-      const resizedImage = shImage.clone().resize({
-        width: size,
-        height: this.maxSize.height,
-        fit: 'inside',
-        withoutEnlargement: true,
-      });
+    await Promise.all(
+      this.targetSizes.flatMap((size) => {
+        // Resize image (only if big enough)
+        const resizedImage = shImage.clone().resize({
+          width: size,
+          height: this.maxSize.height,
+          fit: 'inside',
+          withoutEnlargement: true,
+        });
 
-      // Convert to different formats, suitable for FE
-      const webpImage = resizedImage.clone().toFormat('webp');
-      const avifImage = resizedImage.clone().toFormat('avif');
-      const jpegImage = resizedImage.clone().toFormat('jpeg', {
-        quality: 80,
-        chromaSubsampling: '4:4:4',
-        mozjpeg: true,
-      });
+        // Convert to different formats, suitable for FE
+        const webpImage = resizedImage.clone().toFormat('webp');
+        const avifImage = resizedImage.clone().toFormat('avif');
+        const jpegImage = resizedImage.clone().toFormat('jpeg', {
+          quality: 80,
+          chromaSubsampling: '4:4:4',
+          mozjpeg: true,
+        });
 
-      // Save image of current size in all formats to disk
-      jpegImage.toFile(
-        `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.jpg`,
-      );
-      webpImage.toFile(
-        `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.webp`,
-      );
-      avifImage.toFile(
-        `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.avif`,
-      );
-    });
+        // Save image of current size in all formats to disk
+        return [
+          jpegImage.toFile(
+            `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.jpg`,
+          ),
+          webpImage.toFile(
+            `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.webp`,
+          ),
+          avifImage.toFile(
+            `${env.STORAGE_PATH}/images/${size}/${entity}s/${stem}.avif`,
+          ),
+        ];
+      }),
+    );
 
     // Aspect ratio can be determined from original image metadata, because it will not change. From that also actual max intrinsic width can be determined
     const { width, height } = await shImage.metadata();

--- a/src/crags/services/images.service.ts
+++ b/src/crags/services/images.service.ts
@@ -93,7 +93,6 @@ export class ImagesService {
       extension: inputExtension,
       aspectRatio,
       maxIntrinsicWidth,
-      type,
       title,
       description,
     });

--- a/src/migration/1665752351562-updateDbConstraintsOnSomeRelations.ts
+++ b/src/migration/1665752351562-updateDbConstraintsOnSomeRelations.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class updateDbConstraintsOnSomeRelations1665752351562
+  implements MigrationInterface
+{
+  name = 'updateDbConstraintsOnSomeRelations1665752351562';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "peak" DROP CONSTRAINT "FK_53a36c2642b09e474534a5c13d3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "peak" ALTER COLUMN "countryId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" DROP CONSTRAINT "FK_6a195788507dd2367e76bfdadf0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" ALTER COLUMN "countryId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" DROP CONSTRAINT "FK_cae1d5b69fc10cb70c83f348702"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" ALTER COLUMN "countryId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" DROP CONSTRAINT "FK_42c68e444fd3ec48f66854897e9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" DROP CONSTRAINT "UQ_94157d2971371af83a760bd0c3a"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "routeId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ADD CONSTRAINT "UQ_94157d2971371af83a760bd0c3a" UNIQUE ("routeId", "userId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "peak" ADD CONSTRAINT "FK_53a36c2642b09e474534a5c13d3" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" ADD CONSTRAINT "FK_6a195788507dd2367e76bfdadf0" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" ADD CONSTRAINT "FK_cae1d5b69fc10cb70c83f348702" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ADD CONSTRAINT "FK_42c68e444fd3ec48f66854897e9" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" DROP CONSTRAINT "FK_42c68e444fd3ec48f66854897e9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" DROP CONSTRAINT "FK_cae1d5b69fc10cb70c83f348702"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" DROP CONSTRAINT "FK_6a195788507dd2367e76bfdadf0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "peak" DROP CONSTRAINT "FK_53a36c2642b09e474534a5c13d3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" DROP CONSTRAINT "UQ_94157d2971371af83a760bd0c3a"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ALTER COLUMN "routeId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ADD CONSTRAINT "UQ_94157d2971371af83a760bd0c3a" UNIQUE ("userId", "routeId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "difficulty_vote" ADD CONSTRAINT "FK_42c68e444fd3ec48f66854897e9" FOREIGN KEY ("routeId") REFERENCES "route"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" ALTER COLUMN "countryId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "area" ADD CONSTRAINT "FK_cae1d5b69fc10cb70c83f348702" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" ALTER COLUMN "countryId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ice_fall" ADD CONSTRAINT "FK_6a195788507dd2367e76bfdadf0" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "peak" ALTER COLUMN "countryId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "peak" ADD CONSTRAINT "FK_53a36c2642b09e474534a5c13d3" FOREIGN KEY ("countryId") REFERENCES "country"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/migration/1665753973994-removePictureAddProfileImageToUser.ts
+++ b/src/migration/1665753973994-removePictureAddProfileImageToUser.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class removePictureAddProfileImageToUser1665753973994
+  implements MigrationInterface
+{
+  name = 'removePictureAddProfileImageToUser1665753973994';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "picture"`);
+    await queryRunner.query(`ALTER TABLE "user" ADD "profileImageId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "UQ_5c0981de5dc2a2222a1f0574859" UNIQUE ("profileImageId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_5c0981de5dc2a2222a1f0574859" FOREIGN KEY ("profileImageId") REFERENCES "image"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+
+    // Link all images with 'old' type of profile to users of the same image
+    const profileImages = await queryRunner.query(
+      `SELECT * FROM "image" i WHERE i."type"='profile'`,
+    );
+    for (const image of profileImages) {
+      await queryRunner.query(
+        `UPDATE "user" SET "profileImageId" = '${image.id}' WHERE id = '${image.userId}'`,
+      );
+    }
+
+    // We have two special cases which we will address manually
+    // These two user had more than one profile image (matched from currently used on old pnet).
+    await queryRunner.query(
+      `UPDATE "user" SET "profileImageId" = 'c90bbff0-a973-4166-ae6d-306b7bc5f5f3' WHERE id = 'b88e337a-ebab-4116-a0f7-3491c0607cc2'`,
+    );
+    await queryRunner.query(
+      `UPDATE "user" SET "profileImageId" = '69f6449b-270a-4dee-bd26-f9a4c71cfb0c' WHERE id = '893a32fe-fc96-4585-a88e-2f12790a0c97'`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "image" DROP COLUMN "type"`);
+    await queryRunner.query(`DROP TYPE "public"."image_type_enum"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "image" ADD "author" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "FK_5c0981de5dc2a2222a1f0574859"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "UQ_5c0981de5dc2a2222a1f0574859"`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "profileImageId"`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "profileImageId" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" RENAME COLUMN "profileImageId" TO "picture"`,
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."image_type_enum" AS ENUM('photo', 'sketch', 'map', 'profile')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "image" ADD "type" "public"."image_type_enum" NOT NULL DEFAULT 'photo'`,
+    );
+
+    console.error(
+      `Data in column 'type' of table 'image' is not reconstructable.`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "image" DROP COLUMN "author"`);
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -6,6 +6,8 @@ import {
   UpdateDateColumn,
   BaseEntity,
   OneToMany,
+  OneToOne,
+  JoinColumn,
 } from 'typeorm';
 import { ObjectType, Field, Extensions } from '@nestjs/graphql';
 import { Role } from './role.entity';
@@ -41,13 +43,7 @@ export class User extends BaseEntity {
   @Field({ nullable: true })
   gender?: string;
 
-  @Column({ nullable: true })
-  picture?: string;
-
-  @OneToMany(
-    () => Role,
-    role => role.user,
-  )
+  @OneToMany(() => Role, (role) => role.user)
   @Field(() => [Role], { middleware: [checkRoleMiddleware], nullable: true })
   @Extensions({ roles: ['admin', 'self'] })
   roles: Promise<Role[]>;
@@ -83,21 +79,22 @@ export class User extends BaseEntity {
   @Column({ nullable: true })
   legacy: string;
 
-  @OneToMany(
-    type => ClubMember,
-    clubMember => clubMember.user,
-  )
+  @OneToMany((type) => ClubMember, (clubMember) => clubMember.user)
   clubs: ClubMember[];
 
-  @OneToMany(
-    () => Image,
-    image => image.user,
-  )
+  // All of thr images that the user contributed
+  @OneToMany(() => Image, (image) => image.user)
   @Field(() => [Image])
   images: Promise<Image[]>;
 
+  // Profile image for the user
+  @OneToOne((type) => Image, { nullable: true })
+  @JoinColumn()
+  @Field((type) => Image, { nullable: true })
+  profileImage: Promise<Image[]>;
+
   isAdmin = async () => {
     const roles = await this.roles;
-    return roles ? roles.some(r => r.role == 'admin') : false;
+    return roles ? roles.some((r) => r.role == 'admin') : false;
   };
 }

--- a/test/e2e/upload.e2e-spec.ts
+++ b/test/e2e/upload.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Upload', () => {
       .set('Content-Type', 'multipart/form-data')
       .field('entityType', 'crag')
       .field('title', 'An image of a crag')
-      .field('type', 'photo')
+      .field('author', 'Slavko Majonnezic')
       .field('description', 'This is this crag')
       .attach('image', `${__dirname}/testImage.jpg`)
       .expect(400); // bad request
@@ -59,7 +59,20 @@ describe('Upload', () => {
       .set('Content-Type', 'multipart/form-data')
       .field('entityId', mockData.crags.publishedCrag.id)
       .field('title', 'An image of a crag')
-      .field('type', 'photo')
+      .field('author', 'Slavko Majonezic')
+      .field('description', 'This is this crag')
+      .attach('image', `${__dirname}/testImage.jpg`)
+      .expect(400); // bad request
+  });
+
+  it('should fail if author field is missing', () => {
+    return request(app.getHttpServer())
+      .post('/upload/image')
+      .set('Authorization', `Bearer ${mockData.users.basicUser1.authToken}`)
+      .set('Content-Type', 'multipart/form-data')
+      .field('entityType', 'crag')
+      .field('entityId', mockData.crags.publishedCrag.id)
+      .field('title', 'An image of a crag')
       .field('description', 'This is this crag')
       .attach('image', `${__dirname}/testImage.jpg`)
       .expect(400); // bad request
@@ -73,7 +86,7 @@ describe('Upload', () => {
       .field('entityId', mockData.crags.publishedCrag.id)
       .field('entityType', 'crag')
       .field('title', 'An image of a crag')
-      .field('type', 'photo')
+      .field('author', 'Slavko Majonezic')
       .field('description', 'This is this crag')
       .attach('image', `${__dirname}/testImage.jpg`)
       .expect(201);
@@ -90,13 +103,14 @@ describe('Upload', () => {
     });
 
     // Check that image was added to db
-    const imageId = response.text;
+    const { id: imageId } = JSON.parse(response.text);
     expect(imageId).toBeDefined();
     const [image] = await queryRunner.query(
       `SELECT * FROM image WHERE id = '${imageId}'`,
     );
     expect(image.cragId).toEqual(mockData.crags.publishedCrag.id);
     expect(image.path).toEqual(`crags/${mockData.crags.publishedCrag.slug}`);
+    expect(image.author).toEqual(`Slavko Majonezic`);
   });
 
   it('should succeed uploading a route image', async () => {
@@ -111,7 +125,7 @@ describe('Upload', () => {
       )
       .field('entityType', 'route')
       .field('title', 'An image of a route')
-      .field('type', 'sketch')
+      .field('author', 'Slavko Majonezic')
       .field('description', 'This is this route')
       .attach('image', `${__dirname}/testImage.jpg`)
       .expect(201);
@@ -129,7 +143,7 @@ describe('Upload', () => {
     });
 
     // Check that image was added to db
-    const imageId = response.text;
+    const { id: imageId } = JSON.parse(response.text);
     expect(imageId).toBeDefined();
     const [image] = await queryRunner.query(
       `SELECT * FROM image WHERE id = '${imageId}'`,
@@ -141,6 +155,7 @@ describe('Upload', () => {
     expect(image.path).toEqual(
       `routes/${mockData.crags.publishedCrag.slug}-${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.slug}`,
     );
+    expect(image.author).toEqual(`Slavko Majonezic`);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Fixes a bug, where image was not saved, but BE already responded and then FE tried to load a nonexistent image file.

User entity had a picture column which was removed. Not clear what was it for (it was all empty).

Image entity had a type column which we do not need anymore. 
The only information to transfer from this column was wether an image is some user's profile image. 
The condition was: type=profile and userId=someuserid
Before deletion a new relation was established between user and image: profileImage
I consider cases (2) where one user had more than one profile image a bug. Was manually chosen which image to keep and the others were discarded.

An author column was added to the image entity, because the uploader is not necessarily also the author.

Some migrations were generated (pending still from typeorm update)

Don't forget to run the migrations...

Test this with: https://github.com/plezanje-net/web/pull/436
