### PR TITLE
Area management tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json -i",
+    "test:e2e": "jest --config ./test/jest-e2e.json -i --runInBand",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --dataSource src/ormconfig.ts",
     "migration:run": "npm run typeorm migration:run",
     "migration:revert": "npm run typeorm migration:revert",

--- a/src/activities/entities/activity.entity.ts
+++ b/src/activities/entities/activity.entity.ts
@@ -34,6 +34,8 @@ export class Activity extends BaseEntity {
   @ManyToOne(() => Crag, { nullable: true })
   @Field(() => Crag, { nullable: true })
   crag: Promise<Crag>;
+  @Column({ nullable: true })
+  cragId: string;
 
   @ManyToOne(() => IceFall, { nullable: true })
   @Field(() => IceFall, { nullable: true })
@@ -80,11 +82,7 @@ export class Activity extends BaseEntity {
   @Column({ nullable: true })
   legacy: string;
 
-  @OneToMany(
-    () => ActivityRoute,
-    route => route.activity,
-    { nullable: true },
-  )
+  @OneToMany(() => ActivityRoute, (route) => route.activity, { nullable: true })
   routes: Promise<ActivityRoute[]>;
 
   @ManyToOne(() => User, { nullable: false })

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -33,6 +33,14 @@ import { RoutesTouches } from '../utils/routes-touches.class';
 import { FindRoutesTouchesInput } from '../dtos/find-routes-touches.input';
 import { SideEffect } from '../utils/side-effect.class';
 import { setBuilderCache } from '../../core/utils/entity-cache/entity-cache-helpers';
+import {
+  convertFirstSightOrFlashAfterToRedpoint,
+  convertFirstTickAfterToRepeat,
+  convertFirstTrSightOrFlashAfterToTrRedpoint,
+  convertFirstTrTickAfterToTrRepeat,
+  isTick,
+  isTrTick,
+} from '../../crags/utils/convert-ascents';
 
 @Injectable()
 export class ActivityRoutesService {
@@ -114,25 +122,25 @@ export class ActivityRoutesService {
       queryRunner,
       sideEffects,
     ];
-    if (this.isTick(routeIn.ascentType)) {
-      await this.convertFirstTickAfterToRepeat(...args);
-      await this.convertFirstTrTickAfterToTrRepeat(...args);
-      await this.convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
-    } else if (this.isTrTick(routeIn.ascentType)) {
-      await this.convertFirstSightOrFlashAfterToRedpoint(...args);
-      await this.convertFirstTrTickAfterToTrRepeat(...args);
+    if (isTick(routeIn.ascentType)) {
+      await convertFirstTickAfterToRepeat(...args);
+      await convertFirstTrTickAfterToTrRepeat(...args);
+      await convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
+    } else if (isTrTick(routeIn.ascentType)) {
+      await convertFirstSightOrFlashAfterToRedpoint(...args);
+      await convertFirstTrTickAfterToTrRepeat(...args);
     } else {
       // it is only a try
       // there can really only be one of the below, so one of theese will do nothing. and also could do it in a single query, but leave as is for readability reasons
-      await this.convertFirstSightOrFlashAfterToRedpoint(...args);
-      await this.convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
+      await convertFirstSightOrFlashAfterToRedpoint(...args);
+      await convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
     }
 
     activityRoute.route = Promise.resolve(route);
 
     if (
       route.isProject &&
-      this.isTick(routeIn.ascentType) &&
+      isTick(routeIn.ascentType) &&
       !routeIn.votedDifficulty
     ) {
       throw new HttpException(
@@ -144,7 +152,7 @@ export class ActivityRoutesService {
     // if a vote on difficulty is passed add a new difficulty vote or update existing
     if (routeIn.votedDifficulty) {
       // but first check if a user even can vote (can vote only if the log is a tick)
-      if (!this.isTick(routeIn.ascentType)) {
+      if (!isTick(routeIn.ascentType)) {
         throw new HttpException(
           'Cannot vote on difficulty if not logging a tick.',
           HttpStatus.NOT_ACCEPTABLE,
@@ -198,172 +206,6 @@ export class ActivityRoutesService {
     }
 
     return queryRunner.manager.save(activityRoute);
-  }
-
-  private isTick(ascentType: AscentType) {
-    return tickAscentTypes.has(ascentType);
-  }
-
-  private isTrTick(ascentType: AscentType) {
-    return trTickAscentTypes.has(ascentType);
-  }
-
-  /**
-   * Find user's first tick of a route after the date and convert it to repeat if one exists
-   */
-  private async convertFirstTickAfterToRepeat(
-    routeId: string,
-    userId: string,
-    date: Date,
-    queryRunner: QueryRunner,
-    sideEffects: SideEffect[] = [],
-  ) {
-    const futureTick = await queryRunner.manager
-      .createQueryBuilder(ActivityRoute, 'ar')
-      .where('ar."routeId" = :routeId', { routeId: routeId })
-      .andWhere('ar."userId" = :userId', { userId: userId })
-      .andWhere('ar."ascentType" IN (:...aTypes)', {
-        aTypes: [...firstTickAscentTypes],
-      })
-      .andWhere('ar.date > :arDate', { arDate: date })
-      .orderBy('ar.date', 'ASC') // not realy neccesary, but just in case
-      .getOne(); // If data is valid there can only be one such ascent logged (or none)
-
-    // We do have a tick in the future
-    if (futureTick) {
-      // Remember current activity route state
-      const futureTickBeforeChange = new ActivityRoute();
-      queryRunner.manager.merge(
-        ActivityRoute,
-        futureTickBeforeChange,
-        futureTick,
-      );
-
-      // Convert it to repeat
-      futureTick.ascentType = AscentType.REPEAT;
-      await queryRunner.manager.save(futureTick);
-      sideEffects.push({ before: futureTickBeforeChange, after: futureTick });
-    }
-  }
-
-  /**
-   * Find user's first toprope tick of a route after the date and convert it to toprope repeat if one exists
-   */
-  private async convertFirstTrTickAfterToTrRepeat(
-    routeId: string,
-    userId: string,
-    date: Date,
-    queryRunner: QueryRunner,
-    sideEffects: SideEffect[] = [],
-  ) {
-    const futureTrTick = await queryRunner.manager
-      .createQueryBuilder(ActivityRoute, 'ar')
-      .where('ar."routeId" = :routeId', { routeId: routeId })
-      .andWhere('ar."userId" = :userId', { userId: userId })
-      .andWhere('ar."ascentType" IN (:...aTypes)', {
-        aTypes: [...firstTrTickAscentTypes],
-      })
-      .andWhere('ar.date > :arDate', { arDate: date })
-      .getOne(); // If data is valid there can only be one such ascent logged (or none)
-
-    // We do have a toprope tick in the future
-    if (futureTrTick) {
-      // Remember current activity route state
-      const futureTrTickBeforeChange = new ActivityRoute();
-      queryRunner.manager.merge(
-        ActivityRoute,
-        futureTrTickBeforeChange,
-        futureTrTick,
-      );
-
-      // Convert it to toprope repeat
-      futureTrTick.ascentType = AscentType.T_REPEAT;
-      await queryRunner.manager.save(futureTrTick);
-      sideEffects.push({
-        before: futureTrTickBeforeChange,
-        after: futureTrTick,
-      });
-    }
-  }
-
-  /**
-   * Find user's first onsight or flash of a route after the date and convert it to redpoint if one exists
-   */
-  private async convertFirstSightOrFlashAfterToRedpoint(
-    routeId: string,
-    userId: string,
-    date: Date,
-    queryRunner: QueryRunner,
-    sideEffects: SideEffect[] = [],
-  ) {
-    const futureSightOrFlash = await queryRunner.manager
-      .createQueryBuilder(ActivityRoute, 'ar')
-      .where('ar."routeId" = :routeId', { routeId: routeId })
-      .andWhere('ar."userId" = :userId', { userId: userId })
-      .andWhere('ar."ascentType" IN (:...aTypes)', {
-        aTypes: [AscentType.ONSIGHT, AscentType.FLASH],
-      })
-      .andWhere('ar.date > :arDate', { arDate: date })
-      .getOne(); // If data is valid there can only be one such ascent logged (or none)
-
-    // We do have a flash/onsight in the future
-    if (futureSightOrFlash) {
-      // Remember current activity route state
-      const futureSightOrFlashBeforeChange = new ActivityRoute();
-      queryRunner.manager.merge(
-        ActivityRoute,
-        futureSightOrFlashBeforeChange,
-        futureSightOrFlash,
-      );
-
-      // Convert it to redpoint
-      futureSightOrFlash.ascentType = AscentType.REDPOINT;
-      await queryRunner.manager.save(futureSightOrFlash);
-      sideEffects.push({
-        before: futureSightOrFlashBeforeChange,
-        after: futureSightOrFlash,
-      });
-    }
-  }
-
-  /**
-   * Find user's first toprope onsight or toprope flash of a route after the date and convert it to toprope redpoint if one exists
-   */
-  private async convertFirstTrSightOrFlashAfterToTrRedpoint(
-    routeId: string,
-    userId: string,
-    date: Date,
-    queryRunner: QueryRunner,
-    sideEffects: SideEffect[] = [],
-  ) {
-    const futureTrSightOrFlash = await queryRunner.manager
-      .createQueryBuilder(ActivityRoute, 'ar')
-      .where('ar."routeId" = :routeId', { routeId: routeId })
-      .andWhere('ar."userId" = :userId', { userId: userId })
-      .andWhere('ar."ascentType" IN (:...aTypes)', {
-        aTypes: [AscentType.T_ONSIGHT, AscentType.T_FLASH],
-      })
-      .andWhere('ar.date > :arDate', { arDate: date })
-      .getOne(); // If data is valid there can only be one such ascent logged (or none)
-
-    // We do have a toprope flash/onsight in the future
-    if (futureTrSightOrFlash) {
-      // Remember current activity route state
-      const futureTrSightOrFlashBeforeChange = new ActivityRoute();
-      queryRunner.manager.merge(
-        ActivityRoute,
-        futureTrSightOrFlashBeforeChange,
-        futureTrSightOrFlash,
-      );
-
-      // Convert it to toprope redpoint
-      futureTrSightOrFlash.ascentType = AscentType.T_REDPOINT;
-      await queryRunner.manager.save(futureTrSightOrFlash);
-      sideEffects.push({
-        before: futureTrSightOrFlashBeforeChange,
-        after: futureTrSightOrFlash,
-      });
-    }
   }
 
   /**

--- a/src/audit/audit.module.ts
+++ b/src/audit/audit.module.ts
@@ -20,10 +20,14 @@ import { Country } from '../crags/entities/country.entity';
 import { Area } from '../crags/entities/area.entity';
 import { GradingSystem } from '../crags/entities/grading-system.entity';
 import { DifficultyVote } from '../crags/entities/difficulty-vote.entity';
+import { Activity } from '../activities/entities/activity.entity';
+import { ActivityRoute } from '../activities/entities/activity-route.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
+      Activity,
+      ActivityRoute,
       Audit,
       Route,
       Sector,

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -15,10 +15,8 @@ export class RolesGuard implements CanActivate {
 
     const ctx = GqlExecutionContext.create(context);
 
-    const user = ctx.getContext().req.user;
+    // const user = ctx.  ().req.user;
 
-    return user.roles
-      .map((r: Role) => r.role)
-      .some((r: string) => roles.includes(r));
+    return roles.some((r: string) => roles.includes(r));
   }
 }

--- a/src/crags/crags.module.ts
+++ b/src/crags/crags.module.ts
@@ -64,10 +64,14 @@ import { StarRatingVotesService } from './services/star-rating-votes.service';
 import { StarRatingVote } from './entities/star-rating-vote.entity';
 import { SectorRoutesLoader } from './loaders/sector-routes.loader';
 import { UploadController } from './controllers/upload/upload.controller';
+import { Activity } from '../activities/entities/activity.entity';
+import { ActivityRoute } from '../activities/entities/activity-route.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
+      Activity,
+      ActivityRoute,
       Area,
       Crag,
       Country,

--- a/src/crags/dtos/move-route-to-sector.input.ts
+++ b/src/crags/dtos/move-route-to-sector.input.ts
@@ -1,0 +1,19 @@
+import { InputType, Field } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+
+@InputType()
+export class MoveRouteToSectorInput {
+  @Field()
+  id: string;
+
+  @Field()
+  sectorId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  targetRouteId: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  primaryRoute: string;
+}

--- a/src/crags/entities/route.entity.ts
+++ b/src/crags/entities/route.entity.ts
@@ -117,71 +117,45 @@ export class Route extends BaseEntity {
   @Column({ nullable: true })
   legacy: string;
 
-  @ManyToOne(
-    () => Crag,
-    crag => crag.routes,
-    { onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Crag, (crag) => crag.routes, { onDelete: 'CASCADE' })
   @Field(() => Crag)
   crag: Promise<Crag>;
   @Column()
   cragId: string;
 
-  @ManyToOne(
-    () => Sector,
-    sector => sector.routes,
-    { onDelete: 'CASCADE' },
-  )
+  @ManyToOne(() => Sector, (sector) => sector.routes, { onDelete: 'CASCADE' })
   @Field(() => Sector)
   sector: Promise<Sector>;
   @Column()
   sectorId: string;
 
-  @OneToMany(
-    () => DifficultyVote,
-    difficultyVote => difficultyVote.route,
-    { nullable: true },
-  )
+  @OneToMany(() => DifficultyVote, (difficultyVote) => difficultyVote.route, {
+    nullable: true,
+  })
   @Field(() => [DifficultyVote])
   difficultyVotes: Promise<DifficultyVote[]>;
 
-  @OneToMany(
-    () => StarRatingVote,
-    starRatingVote => starRatingVote.route,
-    { nullable: true },
-  )
-  @Field(type => [StarRatingVote])
+  @OneToMany(() => StarRatingVote, (starRatingVote) => starRatingVote.route, {
+    nullable: true,
+  })
+  @Field((type) => [StarRatingVote])
   starRatingVotes: Promise<StarRatingVote[]>;
 
-  @OneToMany(
-    () => Pitch,
-    pitch => pitch.route,
-    { nullable: true },
-  )
+  @OneToMany(() => Pitch, (pitch) => pitch.route, { nullable: true })
   @Field(() => [Pitch])
   pitches: Promise<Pitch[]>;
 
-  @OneToMany(
-    () => Comment,
-    comment => comment.route,
-    { nullable: true },
-  )
+  @OneToMany(() => Comment, (comment) => comment.route, { nullable: true })
   @Field(() => [Comment])
   comments: Promise<Comment[]>;
 
-  @OneToMany(
-    () => Image,
-    image => image.route,
-    { nullable: true },
-  )
+  @OneToMany(() => Image, (image) => image.route, { nullable: true })
   @Field(() => [Image])
   images: Promise<Image[]>;
 
-  @OneToMany(
-    () => RouteEvent,
-    routeEvent => routeEvent.route,
-    { nullable: true },
-  )
+  @OneToMany(() => RouteEvent, (routeEvent) => routeEvent.route, {
+    nullable: true,
+  })
   @Field(() => [RouteEvent])
   routeEvents: Promise<RouteEvent[]>;
 
@@ -195,10 +169,7 @@ export class Route extends BaseEntity {
   @Column({ name: 'userId', nullable: true })
   userId: string;
 
-  @OneToMany(
-    () => ActivityRoute,
-    activityRoute => activityRoute.route,
-  )
+  @OneToMany(() => ActivityRoute, (activityRoute) => activityRoute.route)
   activityRoutes: ActivityRoute[];
 
   @Field()

--- a/src/crags/resolvers/routes.resolver.ts
+++ b/src/crags/resolvers/routes.resolver.ts
@@ -211,6 +211,18 @@ export class RoutesResolver {
         id: input.targetRouteId,
         user,
       });
+
+      if (
+        route.publishStatus != 'published' ||
+        targetRoute.publishStatus != 'published'
+      ) {
+        throw new BadRequestException('cannot_merge_unpublished_routes');
+      }
+
+      if ((await route.pitches).length || (await targetRoute.pitches).length) {
+        throw new BadRequestException('cannot_merge_multipitch_routes');
+      }
+
       return this.routesService.moveToSector(
         route,
         sector,

--- a/src/crags/services/sectors.service.ts
+++ b/src/crags/services/sectors.service.ts
@@ -195,6 +195,14 @@ export class SectorsService {
     const transaction = new Transaction(this.dataSource);
     await transaction.start();
     try {
+      sector.position =
+        (
+          await transaction.queryRunner.manager.query(
+            `SELECT MAX(position) FROM sector WHERE "cragId" = '${targetCrag.id}'`,
+          )
+        )[0].max + 1;
+
+      console.log();
       sector.cragId = targetCrag.id;
       await transaction.save(sector);
 

--- a/src/crags/utils/convert-ascents.ts
+++ b/src/crags/utils/convert-ascents.ts
@@ -1,0 +1,185 @@
+import { QueryRunner } from 'typeorm';
+import {
+  ActivityRoute,
+  AscentType,
+  firstTickAscentTypes,
+  firstTrTickAscentTypes,
+  tickAscentTypes,
+  trTickAscentTypes,
+} from '../../activities/entities/activity-route.entity';
+import { SideEffect } from '../../activities/utils/side-effect.class';
+
+function isTick(ascentType: AscentType) {
+  return tickAscentTypes.has(ascentType);
+}
+
+function isTrTick(ascentType: AscentType) {
+  return trTickAscentTypes.has(ascentType);
+}
+
+/**
+ * Find user's first tick of a route after the date and convert it to repeat if one exists
+ */
+async function convertFirstTickAfterToRepeat(
+  routeId: string,
+  userId: string,
+  date: Date,
+  queryRunner: QueryRunner,
+  sideEffects: SideEffect[] = [],
+) {
+  const futureTick = await queryRunner.manager
+    .createQueryBuilder(ActivityRoute, 'ar')
+    .where('ar."routeId" = :routeId', { routeId: routeId })
+    .andWhere('ar."userId" = :userId', { userId: userId })
+    .andWhere('ar."ascentType" IN (:...aTypes)', {
+      aTypes: [...firstTickAscentTypes],
+    })
+    .andWhere('ar.date > :arDate', { arDate: date })
+    .orderBy('ar.date', 'ASC') // not realy neccesary, but just in case
+    .getOne(); // If data is valid there can only be one such ascent logged (or none)
+
+  // We do have a tick in the future
+  if (futureTick) {
+    // Remember current activity route state
+    const futureTickBeforeChange = new ActivityRoute();
+    queryRunner.manager.merge(
+      ActivityRoute,
+      futureTickBeforeChange,
+      futureTick,
+    );
+
+    // Convert it to repeat
+    futureTick.ascentType = AscentType.REPEAT;
+    await queryRunner.manager.save(futureTick);
+    sideEffects.push({ before: futureTickBeforeChange, after: futureTick });
+  }
+}
+
+/**
+ * Find user's first toprope tick of a route after the date and convert it to toprope repeat if one exists
+ */
+async function convertFirstTrTickAfterToTrRepeat(
+  routeId: string,
+  userId: string,
+  date: Date,
+  queryRunner: QueryRunner,
+  sideEffects: SideEffect[] = [],
+) {
+  const futureTrTick = await queryRunner.manager
+    .createQueryBuilder(ActivityRoute, 'ar')
+    .where('ar."routeId" = :routeId', { routeId: routeId })
+    .andWhere('ar."userId" = :userId', { userId: userId })
+    .andWhere('ar."ascentType" IN (:...aTypes)', {
+      aTypes: [...firstTrTickAscentTypes],
+    })
+    .andWhere('ar.date > :arDate', { arDate: date })
+    .getOne(); // If data is valid there can only be one such ascent logged (or none)
+
+  // We do have a toprope tick in the future
+  if (futureTrTick) {
+    // Remember current activity route state
+    const futureTrTickBeforeChange = new ActivityRoute();
+    queryRunner.manager.merge(
+      ActivityRoute,
+      futureTrTickBeforeChange,
+      futureTrTick,
+    );
+
+    // Convert it to toprope repeat
+    futureTrTick.ascentType = AscentType.T_REPEAT;
+    await queryRunner.manager.save(futureTrTick);
+    sideEffects.push({
+      before: futureTrTickBeforeChange,
+      after: futureTrTick,
+    });
+  }
+}
+
+/**
+ * Find user's first onsight or flash of a route after the date and convert it to redpoint if one exists
+ */
+async function convertFirstSightOrFlashAfterToRedpoint(
+  routeId: string,
+  userId: string,
+  date: Date,
+  queryRunner: QueryRunner,
+  sideEffects: SideEffect[] = [],
+) {
+  const futureSightOrFlash = await queryRunner.manager
+    .createQueryBuilder(ActivityRoute, 'ar')
+    .where('ar."routeId" = :routeId', { routeId: routeId })
+    .andWhere('ar."userId" = :userId', { userId: userId })
+    .andWhere('ar."ascentType" IN (:...aTypes)', {
+      aTypes: [AscentType.ONSIGHT, AscentType.FLASH],
+    })
+    .andWhere('ar.date > :arDate', { arDate: date })
+    .getOne(); // If data is valid there can only be one such ascent logged (or none)
+
+  // We do have a flash/onsight in the future
+  if (futureSightOrFlash) {
+    // Remember current activity route state
+    const futureSightOrFlashBeforeChange = new ActivityRoute();
+    queryRunner.manager.merge(
+      ActivityRoute,
+      futureSightOrFlashBeforeChange,
+      futureSightOrFlash,
+    );
+
+    // Convert it to redpoint
+    futureSightOrFlash.ascentType = AscentType.REDPOINT;
+    await queryRunner.manager.save(futureSightOrFlash);
+    sideEffects.push({
+      before: futureSightOrFlashBeforeChange,
+      after: futureSightOrFlash,
+    });
+  }
+}
+
+/**
+ * Find user's first toprope onsight or toprope flash of a route after the date and convert it to toprope redpoint if one exists
+ */
+async function convertFirstTrSightOrFlashAfterToTrRedpoint(
+  routeId: string,
+  userId: string,
+  date: Date,
+  queryRunner: QueryRunner,
+  sideEffects: SideEffect[] = [],
+) {
+  const futureTrSightOrFlash = await queryRunner.manager
+    .createQueryBuilder(ActivityRoute, 'ar')
+    .where('ar."routeId" = :routeId', { routeId: routeId })
+    .andWhere('ar."userId" = :userId', { userId: userId })
+    .andWhere('ar."ascentType" IN (:...aTypes)', {
+      aTypes: [AscentType.T_ONSIGHT, AscentType.T_FLASH],
+    })
+    .andWhere('ar.date > :arDate', { arDate: date })
+    .getOne(); // If data is valid there can only be one such ascent logged (or none)
+
+  // We do have a toprope flash/onsight in the future
+  if (futureTrSightOrFlash) {
+    // Remember current activity route state
+    const futureTrSightOrFlashBeforeChange = new ActivityRoute();
+    queryRunner.manager.merge(
+      ActivityRoute,
+      futureTrSightOrFlashBeforeChange,
+      futureTrSightOrFlash,
+    );
+
+    // Convert it to toprope redpoint
+    futureTrSightOrFlash.ascentType = AscentType.T_REDPOINT;
+    await queryRunner.manager.save(futureTrSightOrFlash);
+    sideEffects.push({
+      before: futureTrSightOrFlashBeforeChange,
+      after: futureTrSightOrFlash,
+    });
+  }
+}
+
+export {
+  isTick,
+  isTrTick,
+  convertFirstSightOrFlashAfterToRedpoint,
+  convertFirstTickAfterToRepeat,
+  convertFirstTrSightOrFlashAfterToTrRedpoint,
+  convertFirstTrTickAfterToTrRepeat,
+};

--- a/src/crags/utils/generate-slug.ts
+++ b/src/crags/utils/generate-slug.ts
@@ -1,0 +1,19 @@
+import slugify from 'slugify';
+
+async function generateSlug(
+  name: string,
+  alreadyExistsCondition: (name: string) => Promise<boolean>,
+): Promise<string> {
+  let slug = slugify(name, { lower: true });
+  let suffixCounter = 0;
+  let suffix = '';
+
+  while (await alreadyExistsCondition(slug + suffix)) {
+    suffixCounter++;
+    suffix = '-' + suffixCounter;
+  }
+  slug += suffix;
+  return Promise.resolve(slug);
+}
+
+export default generateSlug;

--- a/src/crags/utils/merge-routes.ts
+++ b/src/crags/utils/merge-routes.ts
@@ -1,0 +1,217 @@
+import { QueryRunner } from 'typeorm';
+import { ActivityRoute } from '../../activities/entities/activity-route.entity';
+import { SideEffect } from '../../activities/utils/side-effect.class';
+import { Transaction } from '../../core/utils/transaction.class';
+import { Comment } from '../entities/comment.entity';
+import { DifficultyVote } from '../entities/difficulty-vote.entity';
+import { RouteProperty } from '../entities/route-property.entity';
+import { Route } from '../entities/route.entity';
+import { StarRatingVote } from '../entities/star-rating-vote.entity';
+import {
+  convertFirstSightOrFlashAfterToRedpoint,
+  convertFirstTickAfterToRepeat,
+  convertFirstTrSightOrFlashAfterToTrRedpoint,
+  convertFirstTrTickAfterToTrRepeat,
+  isTick,
+  isTrTick,
+} from './convert-ascents';
+
+async function mergeRoutes(
+  route: Route,
+  mergeWithRoute: Route,
+  primaryRoute: string,
+  transaction: Transaction,
+): Promise<boolean> {
+  const sourceRoute = primaryRoute === 'target' ? route : mergeWithRoute;
+  const targetRoute = primaryRoute === 'target' ? mergeWithRoute : route;
+
+  await transferDifficultyVotes(sourceRoute.id, targetRoute.id, transaction);
+
+  await transferActivityRoutes(sourceRoute.id, targetRoute.id, transaction);
+  await convertAscentTypesAfterRouteMerge(targetRoute, transaction.queryRunner);
+
+  await transferStarRatings(sourceRoute.id, targetRoute.id, transaction);
+
+  await transferComments(sourceRoute.id, targetRoute.id, transaction);
+
+  await transferRouteProperties(sourceRoute.id, targetRoute.id, transaction);
+
+  await transaction.delete(sourceRoute);
+
+  return true;
+}
+
+async function transferActivityRoutes(
+  routeId: string,
+  targetId: string,
+  transaction: Transaction,
+) {
+  const activityRoutes = await transaction.queryRunner.manager.find(
+    ActivityRoute,
+    {
+      where: { routeId },
+    },
+  );
+  for (const activityRoute of activityRoutes) {
+    activityRoute.routeId = targetId;
+    await transaction.save(activityRoute);
+  }
+}
+
+async function transferDifficultyVotes(
+  routeId: string,
+  targetId: string,
+  transaction: Transaction,
+) {
+  const difficultyVotes = await transaction.queryRunner.manager.find(
+    DifficultyVote,
+    {
+      where: { routeId: routeId },
+    },
+  );
+  for (const difficultyVote of difficultyVotes) {
+    if (difficultyVote.isBase) {
+      await transaction.delete(difficultyVote);
+      continue;
+    }
+
+    const existingUserVote = await transaction.queryRunner.manager.findOne(
+      DifficultyVote,
+      {
+        where: {
+          routeId: targetId,
+          userId: difficultyVote.userId,
+        },
+      },
+    );
+    if (
+      existingUserVote &&
+      existingUserVote.created >= difficultyVote.created
+    ) {
+      await transaction.delete(difficultyVote);
+      continue;
+    }
+
+    if (existingUserVote && existingUserVote.created < difficultyVote.created) {
+      await transaction.delete(existingUserVote);
+    }
+    difficultyVote.routeId = targetId;
+    await transaction.save(difficultyVote);
+  }
+}
+
+async function transferStarRatings(
+  routeId: string,
+  targetId: string,
+  transaction: Transaction,
+) {
+  const starRatingVotes = await transaction.queryRunner.manager.find(
+    StarRatingVote,
+    {
+      where: { routeId: routeId },
+    },
+  );
+  for (const starRatingVote of starRatingVotes) {
+    const existingUserVote = await transaction.queryRunner.manager.findOne(
+      StarRatingVote,
+      {
+        where: {
+          routeId: targetId,
+          userId: starRatingVote.userId,
+        },
+      },
+    );
+    if (
+      existingUserVote &&
+      existingUserVote.created >= starRatingVote.created
+    ) {
+      await transaction.delete(starRatingVote);
+      continue;
+    }
+
+    if (existingUserVote && existingUserVote.created < starRatingVote.created) {
+      await transaction.delete(existingUserVote);
+    }
+    starRatingVote.routeId = targetId;
+    await transaction.save(starRatingVote);
+  }
+}
+
+async function transferRouteProperties(
+  routeId: string,
+  targetId: string,
+  transaction: Transaction,
+) {
+  const routeProperties = await transaction.queryRunner.manager.find(
+    RouteProperty,
+    {
+      where: { routeId: routeId },
+    },
+  );
+  for (const routeProperty of routeProperties) {
+    const existingRouteProperty = await transaction.queryRunner.manager.findOne(
+      RouteProperty,
+      {
+        where: {
+          routeId: targetId,
+          propertyTypeId: routeProperty.propertyTypeId,
+        },
+      },
+    );
+    if (existingRouteProperty) {
+      await transaction.delete(routeProperty);
+      continue;
+    }
+
+    routeProperty.routeId = targetId;
+    await transaction.save(routeProperty);
+  }
+}
+
+async function transferComments(
+  routeId: string,
+  targetId: string,
+  transaction: Transaction,
+) {
+  const comments = await transaction.queryRunner.manager.find(Comment, {
+    where: { routeId },
+  });
+  for (const comment of comments) {
+    comment.routeId = targetId;
+    await transaction.save(comment);
+  }
+}
+
+async function convertAscentTypesAfterRouteMerge(
+  route: Route,
+  queryRunner: QueryRunner,
+) {
+  const activityRoutes = await queryRunner.manager.find(ActivityRoute, {
+    where: { routeId: route.id },
+    order: { date: 'ASC' },
+  });
+  for (const activityRoute of activityRoutes) {
+    const args: [string, string, Date, QueryRunner, SideEffect[]] = [
+      route.id,
+      activityRoute.userId,
+      activityRoute.date,
+      queryRunner,
+      [],
+    ];
+    if (isTick(activityRoute.ascentType)) {
+      await convertFirstTickAfterToRepeat(...args);
+      await convertFirstTrTickAfterToTrRepeat(...args);
+      await convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
+    } else if (isTrTick(activityRoute.ascentType)) {
+      await convertFirstSightOrFlashAfterToRedpoint(...args);
+      await convertFirstTrTickAfterToTrRepeat(...args);
+    } else {
+      // it is only a try
+      // there can really only be one of the below, so one of theese will do nothing. and also could do it in a single query, but leave as is for readability reasons
+      await convertFirstSightOrFlashAfterToRedpoint(...args);
+      await convertFirstTrSightOrFlashAfterToTrRedpoint(...args);
+    }
+  }
+}
+
+export { mergeRoutes };

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -85,7 +85,6 @@ const seedDatabase = async (qr: QueryRunner, app) => {
           },
         },
       },
-
       inReviewCrag: {
         id: 'a700997e-78f3-4f5b-9faf-2f8d0f0ab8e8',
         sectors: {
@@ -99,7 +98,6 @@ const seedDatabase = async (qr: QueryRunner, app) => {
           },
         },
       },
-
       draftCrag: {
         id: '2447ac1c-ba42-4f72-9fea-8489b91df5aa',
         sectors: {
@@ -108,6 +106,38 @@ const seedDatabase = async (qr: QueryRunner, app) => {
             routes: {
               draftRoute: {
                 id: 'c7119b96-cfbc-48de-81f0-25830cce1310',
+              },
+            },
+          },
+        },
+      },
+      cragWithMultipleSectors: {
+        id: '5cc7f53e-525a-4ef9-9792-8400ccdc0ae2',
+        slug: 'cre-tata',
+        sectors: {
+          firstSector: {
+            id: '2c76bd33-89c2-4a7c-80e1-c9ad9d1b8ca8',
+            routes: {
+              firstRoute: {
+                id: 'fc30922b-fcc6-4461-9776-fe7692f55471',
+                slug: 'route-slug-fc30922b',
+              },
+              secondRoute: {
+                id: '8a63ddcc-9b9a-4124-847b-f63801ca7769',
+                slug: 'route-slug-8a63ddcc',
+              },
+            },
+          },
+          secondSector: {
+            id: '43aa6c1a-7d39-46f6-ac9c-b7304351211c',
+            routes: {
+              firstRoute: {
+                id: '37dafa58-352c-4d41-9077-9dd71f5154e2',
+                slug: 'route-slug-37dafa58',
+              },
+              secondRoute: {
+                id: '87ca8c06-3a92-434a-a666-94be5842a27e',
+                slug: 'route-slug-87ca8c06',
               },
             },
           },
@@ -180,6 +210,11 @@ const seedDatabase = async (qr: QueryRunner, app) => {
     `INSERT INTO crag (id, name, slug, "countryId", "defaultGradingSystemId", type, "publishStatus", "isHidden", "userId")
     VALUES ('${mockData.crags.draftCrag.id}', 'Nova grapa', 'nova-grapa', '${mockData.countries.slovenia.id}', 'french', 'sport', 'draft', false, '${mockData.users.basicUser1.id}')`,
   );
+  // crag with multiple sectors
+  await qr.query(
+    `INSERT INTO crag (id, name, slug, "countryId", "defaultGradingSystemId", type, "publishStatus", "isHidden", "userId")
+    VALUES ('${mockData.crags.cragWithMultipleSectors.id}', 'Cre tata', '${mockData.crags.cragWithMultipleSectors.slug}', '${mockData.countries.slovenia.id}', 'french', 'sport', 'published', false, '${mockData.users.basicUser1.id}')`,
+  );
 
   // Add some sectors
   // published sector in published crag
@@ -202,6 +237,14 @@ const seedDatabase = async (qr: QueryRunner, app) => {
     `INSERT INTO sector (id, name, label, position, "cragId", "publishStatus")
     VALUES ('${mockData.crags.inReviewCrag.sectors.inReviewSector.id}', 'Pregledni sektor', 'B', 1, '${mockData.crags.inReviewCrag.id}', 'in_review')`,
   );
+  // sectors in multiple sector crag
+  await qr.query(
+    `INSERT INTO sector (id, name, label, position, "cragId", "publishStatus")
+    VALUES 
+      ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', 'Ostajajoci sektor', 'A', 1, '${mockData.crags.cragWithMultipleSectors.id}', 'published'),
+      ('${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}', 'Odhajajoci sektor', 'B', 2, '${mockData.crags.cragWithMultipleSectors.id}', 'published')
+    `,
+  );
 
   // Add some routes
   // published route in published sector in published crag
@@ -223,6 +266,16 @@ const seedDatabase = async (qr: QueryRunner, app) => {
   await qr.query(
     `INSERT INTO route (id, name, length, position, "sectorId", "cragId", "routeTypeId", "isProject", "defaultGradingSystemId", difficulty, slug, "publishStatus")
     VALUES ('${mockData.crags.inReviewCrag.sectors.inReviewSector.routes.inReviewRoute.id}', 'Ta v pregledu', '14', 1, '${mockData.crags.inReviewCrag.sectors.inReviewSector.id}', '${mockData.crags.inReviewCrag.id}', 'sport', false, 'french', '200', 'ta-v-pregledu', 'in_review')`,
+  );
+  // routes in multipe sector crag
+  await qr.query(
+    `INSERT INTO route (id, name, length, position, "sectorId", "cragId", "routeTypeId", "isProject", "defaultGradingSystemId", difficulty, slug, "publishStatus")
+    VALUES 
+      ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', 'Route Slug fc30922b', '11', 1, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.slug}', 'published'),
+      ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.id}', 'Route Slug 8a63ddcc', '11', 2, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.slug}', 'published'),
+      ('${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', 'Route Slug 37dafa58', '11', 1, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.slug}', 'published'),
+      ('${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}', 'Route Slug 87ca8c06', '11', 2, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.slug}', 'published')
+    `,
   );
 
   return mockData;

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -71,7 +71,7 @@ const seedDatabase = async (qr: QueryRunner, app) => {
             routes: {
               publishedRoute: {
                 id: 'c9b9b9e9-1b9a-4b9a-8b9a-1b9a4b9a8b9a',
-                slug: 'highlyUnprobableSlug09832rf2',
+                slug: 'highly-unprobable-name-09832rf2',
               },
             },
           },
@@ -120,7 +120,7 @@ const seedDatabase = async (qr: QueryRunner, app) => {
             routes: {
               firstRoute: {
                 id: 'fc30922b-fcc6-4461-9776-fe7692f55471',
-                slug: 'route-slug-fc30922b',
+                slug: 'highly-unprobable-name-09832rf2',
               },
               secondRoute: {
                 id: '8a63ddcc-9b9a-4124-847b-f63801ca7769',
@@ -271,7 +271,7 @@ const seedDatabase = async (qr: QueryRunner, app) => {
   await qr.query(
     `INSERT INTO route (id, name, length, position, "sectorId", "cragId", "routeTypeId", "isProject", "defaultGradingSystemId", difficulty, slug, "publishStatus")
     VALUES 
-      ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', 'Route Slug fc30922b', '11', 1, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.slug}', 'published'),
+      ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', 'Highly Unprobable Name 09832rf2', '11', 1, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.slug}', 'published'),
       ('${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.id}', 'Route Slug 8a63ddcc', '11', 2, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.slug}', 'published'),
       ('${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', 'Route Slug 37dafa58', '11', 1, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.slug}', 'published'),
       ('${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}', 'Route Slug 87ca8c06', '11', 2, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}', '${mockData.crags.cragWithMultipleSectors.id}', 'sport', false, 'french', '200', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.slug}', 'published')

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -23,6 +23,9 @@ const initializeDbConn = async (app: INestApplication): Promise<DataSource> => {
   await conn.createQueryRunner().query(query);
   await conn.synchronize(true);
 
+  const triggersQuery = fs.readFileSync('./test/e2e/sql/triggers.sql', 'utf8');
+  await conn.createQueryRunner().query(triggersQuery);
+
   return conn;
 };
 

--- a/test/e2e/routeMigration.e2e-spec.ts
+++ b/test/e2e/routeMigration.e2e-spec.ts
@@ -137,8 +137,8 @@ describe('RouteMigration', () => {
       .send({
         query: `
         mutation {
-          moveRouteToSector(input: { 
-            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}", 
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
             sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
             targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
             primaryRoute: "source"
@@ -166,8 +166,8 @@ describe('RouteMigration', () => {
       .send({
         query: `
         mutation {
-          moveRouteToSector(input: { 
-            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}", 
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
             sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
             targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
             primaryRoute: "source"

--- a/test/e2e/routeMigration.e2e-spec.ts
+++ b/test/e2e/routeMigration.e2e-spec.ts
@@ -1,0 +1,297 @@
+import request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../../src/app.module';
+import { DataSource, QueryRunner } from 'typeorm';
+import { MailService } from '../../src/notification/services/mail.service';
+import { initializeDbConn, prepareEnvironment, seedDatabase } from './helpers';
+import { INestApplication } from '@nestjs/common';
+import { CragsModule } from '../../src/crags/crags.module';
+import { ActivityType } from '../../src/activities/entities/activity.entity';
+import { AscentType } from '../../src/activities/entities/activity-route.entity';
+
+describe('RouteMigration', () => {
+  let app: INestApplication;
+  let conn: DataSource;
+  let queryRunner: QueryRunner;
+
+  let mockData: any;
+
+  beforeEach(async () => {
+    prepareEnvironment();
+
+    const mailService = { send: () => Promise.resolve({}) };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, CragsModule],
+    })
+      .overrideProvider(MailService)
+      .useValue(mailService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+
+    await app.init();
+
+    conn = await initializeDbConn(app);
+    queryRunner = conn.createQueryRunner();
+
+    mockData = await seedDatabase(queryRunner, app);
+    mockData.activities = {
+      activityAcrossSectors: {
+        id: '85853921-9e23-4351-8c20-eeb74bb0f26c',
+        date: '2001-02-01',
+      },
+      activityWithDuplicateRoute: {
+        id: '85853921-9e23-8c20-8c20-eeb74bb0f26c',
+        date: '2001-04-01',
+      },
+    };
+
+    await queryRunner.query(
+      `INSERT INTO activity (id, "cragId", type, name, date, "userId")
+        VALUES ('${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.id}', '${ActivityType.CRAG}', 'Activity to be split', '${mockData.activities.activityAcrossSectors.date}', '${mockData.users.basicUser1.id}'),
+        ('${mockData.activities.activityWithDuplicateRoute.id}', '${mockData.crags.cragWithMultipleSectors.id}', '${ActivityType.CRAG}', 'Activity to be split', '${mockData.activities.activityWithDuplicateRoute.date}', '${mockData.users.basicUser1.id}')
+        `,
+    );
+    await queryRunner.query(
+      `INSERT INTO activity_route ("ascentType", publish, "activityId", "routeId", "userId", date)
+        VALUES
+          ('${AscentType.ONSIGHT}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityAcrossSectors.date}'),
+          ('${AscentType.ONSIGHT}', 'log', '${mockData.activities.activityWithDuplicateRoute.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityWithDuplicateRoute.date}')
+          `,
+    );
+
+    await queryRunner.query(
+      `INSERT INTO difficulty_vote (difficulty, created, "userId", "routeId", "isBase", "includedInCalculation")
+        VALUES
+          (1000, '2001-01-01', null, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', true, false),
+          (1100, '${mockData.activities.activityAcrossSectors.date}', '${mockData.users.basicUser1.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', false, true),
+          (1200, '${mockData.activities.activityAcrossSectors.date}', '${mockData.users.basicUser2.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', false, false),
+          (1100, '2001-01-20', null, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', true, true),
+          (1200, '${mockData.activities.activityWithDuplicateRoute.date}', '${mockData.users.basicUser1.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', false, false)
+        `,
+    );
+
+    await queryRunner.query(
+      `INSERT INTO comment (type, "userId", content, status, "routeId") VALUES
+        ('comment', '${mockData.users.basicUser1.id}', 'Comment 1', 'active', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'),
+        ('comment', '${mockData.users.basicUser1.id}', 'Comment 1', 'active', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}'),
+        ('comment', '${mockData.users.basicUser1.id}', 'Comment 3', 'active', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}'),
+        ('comment', '${mockData.users.basicUser1.id}', 'Comment 4', 'active', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}')
+      `,
+    );
+
+    await queryRunner.query(
+      `INSERT INTO star_rating_vote (stars, "userId", created, "routeId") VALUES
+        (1, '${mockData.users.basicUser1.id}', '${mockData.activities.activityAcrossSectors.date}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'),
+        (1, '${mockData.users.basicUser2.id}', '${mockData.activities.activityWithDuplicateRoute.date}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'),
+        (2, '${mockData.users.basicUser1.id}', '${mockData.activities.activityWithDuplicateRoute.date}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}'),
+        (2, '${mockData.users.basicUser2.id}', '${mockData.activities.activityAcrossSectors.date}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}')
+      `,
+    );
+
+    await queryRunner.query(
+      `INSERT INTO property_type (id, name, "valueType", position) VALUES
+        ('nrQuickdraws', 'Nr Quickdraws', 'number', 1),
+        ('firstAscent', 'First Ascent', 'string', 2)
+      `,
+    );
+
+    await queryRunner.query(
+      `INSERT INTO route_property ("propertyTypeId", "stringValue", "numValue", "routeId", position) VALUES
+        ('firstAscent', 'First first ascensionist', null, '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', 0),
+        ('firstAscent', 'Second first ascensionist', null, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', 0),
+        ('nrQuickdraws', null, 5, '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', 0)
+      `,
+    );
+  });
+
+  it('should move the route to a new sector', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: { id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}", sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}" })
+        }
+      `,
+      })
+      .expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+    const sourceSectorRoutes = await queryRunner.query(
+      `SELECT * FROM route WHERE "sectorId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}'`,
+    );
+    expect(sourceSectorRoutes.length).toBe(1);
+    const targetSectorRoutes = await queryRunner.query(
+      `SELECT * FROM route WHERE "sectorId" = '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}'`,
+    );
+    expect(targetSectorRoutes.length).toBe(3);
+  });
+
+  it('should merge the routes if target specified', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: { 
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}", 
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+    const sourceSectorRoutes = await queryRunner.query(
+      `SELECT * FROM route WHERE "sectorId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}'`,
+    );
+    expect(sourceSectorRoutes.length).toBe(1);
+    const targetSectorRoutes = await queryRunner.query(
+      `SELECT * FROM route WHERE "sectorId" = '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}'`,
+    );
+    expect(targetSectorRoutes.length).toBe(2);
+  });
+
+  it('should change ascent types if invalid state happens after merge', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: { 
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}", 
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+    expect(response.body.errors).toBeUndefined();
+    const onsightAscentsOfRoute = await queryRunner.query(
+      `SELECT * FROM activity_route WHERE "routeId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}' AND "userId" = '${mockData.users.basicUser1.id}' AND "ascentType" = '${AscentType.ONSIGHT}'`,
+    );
+    expect(onsightAscentsOfRoute.length).toBe(1);
+  });
+
+  it('should only keep latest base and each user grade', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+    expect(response.body.errors).toBeUndefined();
+    const difficultyVotes = await queryRunner.query(
+      `SELECT * FROM difficulty_vote WHERE "routeId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'`,
+    );
+    expect(difficultyVotes.length).toBe(3);
+
+    const updatedRoute = await queryRunner.query(
+      `SELECT * FROM route WHERE id = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'`,
+    );
+    expect(updatedRoute[0].difficulty).toBe(1200);
+  });
+
+  it('should transfer all comments to target route', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+    expect(response.body.errors).toBeUndefined();
+
+    const comments = await queryRunner.query(
+      `SELECT * FROM comment WHERE "routeId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'`,
+    );
+    expect(comments.length).toBe(3);
+  });
+
+  it('should use only the latest star rating per user', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+    expect(response.body.errors).toBeUndefined();
+
+    const starRatings = await queryRunner.query(
+      `SELECT * FROM star_rating_vote WHERE "routeId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}'`,
+    );
+    expect(starRatings.length).toBe(2);
+    expect(starRatings[0].stars + starRatings[1].stars).toBe(3);
+  });
+
+  it('should migrate route properties from secondary route unless already present on target', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveRouteToSector(input: {
+            id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}",
+            sectorId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}",
+            targetRouteId: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}",
+            primaryRoute: "source"
+          })
+        }
+      `,
+      })
+      .expect(200);
+    expect(response.body.errors).toBeUndefined();
+
+    const routeProperties = await queryRunner.query(
+      `SELECT * FROM route_property WHERE "routeId" = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}' ORDER BY "propertyTypeId" ASC`,
+    );
+    expect(routeProperties.length).toBe(2);
+    expect(routeProperties[0].stringValue).toBe('First first ascensionist');
+    expect(routeProperties[1].numValue).toBe(5);
+  });
+
+  afterEach(async () => {
+    await conn.destroy();
+    await app.close();
+  });
+});

--- a/test/e2e/sectorMigration.e2e-spec.ts
+++ b/test/e2e/sectorMigration.e2e-spec.ts
@@ -1,0 +1,124 @@
+import request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../../src/app.module';
+import { DataSource, QueryRunner } from 'typeorm';
+import { MailService } from '../../src/notification/services/mail.service';
+import { initializeDbConn, prepareEnvironment, seedDatabase } from './helpers';
+import { INestApplication } from '@nestjs/common';
+import { CragsModule } from '../../src/crags/crags.module';
+import { ActivityType } from '../../src/activities/entities/activity.entity';
+import { AscentType } from '../../src/activities/entities/activity-route.entity';
+
+describe('SectorMigration', () => {
+  let app: INestApplication;
+  let conn: DataSource;
+  let queryRunner: QueryRunner;
+
+  let mockData: any;
+
+  beforeAll(async () => {
+    prepareEnvironment();
+
+    const mailService = { send: () => Promise.resolve({}) };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule, CragsModule],
+    })
+      .overrideProvider(MailService)
+      .useValue(mailService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+
+    await app.init();
+
+    conn = await initializeDbConn(app);
+    queryRunner = conn.createQueryRunner();
+
+    mockData = await seedDatabase(queryRunner, app);
+    mockData.activities = {
+      activityAcrossSectors: {
+        id: '85853921-9e23-4351-8c20-eeb74bb0f26c',
+      },
+    };
+
+    await queryRunner.query(
+      `INSERT INTO activity (id, "cragId", type, name, date, "userId")
+      VALUES ('${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.id}', '${ActivityType.CRAG}', 'Activity to be split', '2001-01-01', '${mockData.users.basicUser1.id}')`,
+    );
+    await queryRunner.query(
+      `INSERT INTO activity_route ("ascentType", publish, "activityId", "routeId", "userId")
+      VALUES 
+        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}'),
+        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}'),
+        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}'),
+        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}')
+      `,
+    );
+  });
+
+  it('should move the sector to the new crag', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveSectorToCrag(id: "${mockData.crags.cragWithMultipleSectors.sectors.secondSector.id}", cragId: "${mockData.crags.publishedCrag.id}")
+        }
+      `,
+      })
+      .expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+    const sectors = await queryRunner.query(
+      `SELECT * FROM sector WHERE "cragId" = '${mockData.crags.cragWithMultipleSectors.id}'`,
+    );
+    expect(sectors.length).toBe(1);
+  });
+
+  it('should create activity and link activity routes linked to the new crag', async () => {
+    const activityRoutes = await queryRunner.query(
+      `SELECT * FROM activity_route WHERE "activityId" = '${mockData.activities.activityAcrossSectors.id}'`,
+    );
+    expect(activityRoutes.length).toBe(2);
+  });
+
+  it('should not delete previous activity if there are still activity routes link to the old crag', async () => {
+    const activity = await queryRunner.query(
+      `SELECT * FROM activity WHERE id = '${mockData.activities.activityAcrossSectors.id}'`,
+    );
+    expect(activity.length).toBe(1);
+  });
+
+  it('should delete previous activity if all activity routes have been moved to another crag', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${mockData.users.editorUser.authToken}`)
+      .send({
+        query: `
+        mutation {
+          moveSectorToCrag(id: "${mockData.crags.cragWithMultipleSectors.sectors.firstSector.id}", cragId: "${mockData.crags.publishedCrag.id}")
+        }
+      `,
+      })
+      .expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+
+    const activityRoutes = await queryRunner.query(
+      `SELECT * FROM activity_route WHERE "activityId" = '${mockData.activities.activityAcrossSectors.id}'`,
+    );
+    expect(activityRoutes.length).toBe(0);
+
+    const activity = await queryRunner.query(
+      `SELECT * FROM activity WHERE id = '${mockData.activities.activityAcrossSectors.id}'`,
+    );
+    expect(activity.length).toBe(0);
+  });
+
+  afterAll(async () => {
+    await conn.destroy();
+    await app.close();
+  });
+});

--- a/test/e2e/sectorMigration.e2e-spec.ts
+++ b/test/e2e/sectorMigration.e2e-spec.ts
@@ -117,6 +117,13 @@ describe('SectorMigration', () => {
     expect(activity.length).toBe(0);
   });
 
+  it('should update route slug if collision detected in the new crag', async () => {
+    const duplicateSlugsInCrag = await queryRunner.query(
+      `SELECT slug FROM route WHERE "cragId" = '${mockData.crags.publishedCrag.id}' GROUP BY slug HAVING COUNT(id) > 1`,
+    );
+    expect(duplicateSlugsInCrag.length).toBe(0);
+  });
+
   afterAll(async () => {
     await conn.destroy();
     await app.close();

--- a/test/e2e/sql/triggers.sql
+++ b/test/e2e/sql/triggers.sql
@@ -1,0 +1,259 @@
+CREATE OR REPLACE FUNCTION public.convert_first_repeat_to_redpoint()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+        DECLARE
+            ardate timestamp;
+        BEGIN
+
+            -- if deleted was a 'real' tick then convert first repeat to redpoint and possibly toprope repeat to toprope redpoint
+            IF  OLD."ascentType" = 'redpoint' OR OLD."ascentType" = 'flash' OR OLD."ascentType" = 'onsight' THEN
+
+                -- find first repeat by same user for same route and convert it to redpoint if such log exists
+                UPDATE activity_route
+                SET "ascentType" = 'redpoint'
+                WHERE id = (
+                    SELECT id FROM activity_route
+                    WHERE "routeId" = OLD."routeId"
+                    AND "userId" = OLD."userId"
+                    AND "ascentType" = 'repeat'
+                    ORDER BY date
+                    LIMIT 1)
+                RETURNING date INTO ardate;
+
+                -- find first toprope repeat and if it is logged before the new redpoint ascent convert it to toprope redpoint
+                -- that is: Find first TR Repeat and convert it to TR Redpoint, but only if: TR Repeat is before new Redpoint OR new Redpoint does not exist
+                UPDATE activity_route
+                SET "ascentType" = 't_redpoint'
+                WHERE id =(
+                    SELECT id FROM activity_route
+                    WHERE "routeId" = OLD."routeId"
+                    AND "userId" = OLD."userId"
+                    AND (ardate IS NULL OR date < ardate)  -- if above update did nothing skip this condition
+                    AND "ascentType" = 't_repeat'
+                    ORDER BY date
+                    LIMIT 1
+                    );
+
+            -- if deleted was a toprope tick then convert first toprope repeat to toprope redpoint but only if no real tick is in between
+            ELSEIF OLD."ascentType" = 't_redpoint' OR OLD."ascentType" = 't_flash' OR OLD."ascentType" = 't_onsight' THEN
+
+                -- find first real tick (if it exists) and save the time
+                SELECT date INTO ardate
+                FROM activity_route
+                WHERE "routeId" = OLD."routeId"
+                AND "userId" = OLD."userId"
+                AND ("ascentType" = 'redpoint' OR "ascentType" = 'flash' OR "ascentType" = 'onsight')
+                ORDER BY date
+                LIMIT 1;
+
+                -- convert first toprope repeat that might be logged before the possible real tick log to toprope redpoint
+                UPDATE activity_route
+                SET "ascentType" = 't_redpoint'
+                WHERE id = (
+                    SELECT id FROM activity_route
+                    WHERE "routeId" = OLD."routeId"
+                    AND "userId" = OLD."userId"
+                    AND "ascentType" = 't_repeat'
+                    AND (ardate IS NULL OR date < ardate)
+                    ORDER BY date
+                    LIMIT 1
+                    );
+            END IF;
+
+            RETURN NULL;
+        END
+        $function$
+;
+
+CREATE OR REPLACE FUNCTION public.delete_difficulty_vote()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+          DECLARE
+              numTicksLeft INTEGER;
+          BEGIN            
+              -- see if user has any ticks of this route left
+              SELECT count(*) INTO numTicksLeft FROM activity_route
+              WHERE "routeId" = OLD."routeId"
+              AND "userId" = OLD."userId"
+              AND "ascentType" IN ('redpoint', 'flash', 'onsight', 'repeat');
+  
+              -- if this was not the last tick, no need to do anything
+              IF (numTicksLeft > 0) THEN
+                  RETURN NULL;
+              END IF;
+  
+              -- delete users difficulty vote for this route
+              DELETE FROM difficulty_vote
+              WHERE "userId" = OLD."userId"
+              AND "routeId" = OLD."routeId";
+  
+              RETURN NULL;
+          END
+          $function$
+;
+
+CREATE OR REPLACE FUNCTION public.min_max_route_difficulty_of_crag()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+            DECLARE
+                mindiff integer;
+                maxdiff integer;
+            BEGIN
+                -- get min and max difficulty of all routes for the crag to which a route that has been added/deleted/modified belongs to
+                SELECT INTO mindiff, maxdiff
+                    min(r.difficulty), max(r.difficulty)
+                FROM route r
+                WHERE "cragId" = COALESCE(NEW."cragId", OLD."cragId");
+
+                UPDATE crag
+                SET "minDifficulty" = mindiff,
+                    "maxDifficulty" = maxdiff
+                WHERE id = COALESCE(NEW."cragId", OLD."cragId");
+
+                RETURN NEW;
+            END
+            $function$
+;
+
+CREATE OR REPLACE FUNCTION public.recalculate_route_difficulty()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+        DECLARE
+            numvotes integer;
+            calcedDifficulty double precision;
+            roundedFifth integer;
+        BEGIN
+
+            -- temporarily disable triggers for this session so that we don't get a recursive loop while altering the difficulty_vote table
+            SET session_replication_role = replica;
+
+            -- one vote, two votes, more than two votes
+            SELECT count(*) INTO numvotes
+            FROM difficulty_vote
+            WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId");   -- update and insert pass NEW, update and delete pass OLD
+
+            CASE numvotes
+                WHEN 0 THEN
+                    -- only vote was apparently just deleted so set difficulty of a route to null
+                    calcedDifficulty = null;
+
+                    -- if no vote route has no difficulty, so apparently it is a project
+                    UPDATE route
+                    SET "isProject" = TRUE
+                    WHERE id = COALESCE(NEW."routeId", OLD."routeId");
+
+                WHEN 1, 2 THEN
+                    -- only one or two votes, so only the base grade is included in calculation
+                    calcedDifficulty =(
+                        SELECT difficulty
+                        FROM difficulty_vote
+                        WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId") AND "isBase" = true
+                    );
+
+                    UPDATE difficulty_vote
+                    SET "includedInCalculation" = COALESCE("isBase", false)
+                    WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId");
+
+                ELSE
+                    -- more than 2 votes. skip top and bottom 20% grades, and use all others to get the average
+
+                    -- find out how many lowest and highest grades to skip
+                    roundedFifth = ROUND(numvotes::numeric/5);
+
+                    -- set all as not included in calc, then set only ones that should be as included in calc
+                    UPDATE difficulty_vote
+                    SET "includedInCalculation" = FALSE
+                    WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId");
+
+                    WITH isIncluded AS (
+                        SELECT id
+                        FROM difficulty_vote
+                        where "routeId" = COALESCE(NEW."routeId", OLD."routeId")
+                        order by difficulty, id     -- add id to order to keep consistency on many same excluded difficulties
+                        offset roundedFifth
+                        limit  numvotes - roundedFifth - roundedFifth
+                    )
+                    UPDATE difficulty_vote dv
+                    SET "includedInCalculation" = true
+                    FROM isIncluded
+                    WHERE dv.id = isIncluded.id;
+
+                    -- calculate difficulty only from 'middle' 3/5 of votes
+                    calcedDifficulty =(
+                        SELECT AVG(difficulty)
+                        FROM difficulty_vote
+                        WHERE "routeId" = COALESCE(NEW."routeId", OLD."routeId") AND "includedInCalculation" = true
+                    );
+            END CASE;
+
+            UPDATE route
+            SET difficulty = calcedDifficulty
+            WHERE id = COALESCE(NEW."routeId", OLD."routeId");
+
+            -- reenable triggers after all is done
+            SET session_replication_role = DEFAULT;
+
+            RETURN NEW;
+        END;
+        $function$
+;
+
+CREATE OR REPLACE FUNCTION public.recount_routes_of_crag()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+        DECLARE
+            numroutes integer;
+        BEGIN
+            -- get number of routes for the crag whose route is being inserted or deleted
+            SELECT COUNT (*) INTO numroutes
+            FROM crag c
+            LEFT JOIN route r ON c.id = r."cragId"
+            WHERE c.id = COALESCE(NEW."cragId", OLD."cragId");
+        
+            UPDATE crag
+            SET "nrRoutes" = numroutes
+            WHERE id = COALESCE(NEW."cragId", OLD."cragId");
+        
+            RETURN NEW;
+        END
+        $function$
+;
+
+
+create trigger convert_first_repeat_to_redpoint after
+delete
+    on
+    public.activity_route for each row execute function convert_first_repeat_to_redpoint();
+create trigger delete_difficulty_vote after
+delete
+    on
+    public.activity_route for each row execute function delete_difficulty_vote();
+
+create trigger route_difficulty_vote after
+insert
+    or
+delete
+    or
+update
+    on
+    public.difficulty_vote for each row execute function recalculate_route_difficulty();
+
+create trigger crag_min_max_route_difficulty after
+insert
+    or
+delete
+    or
+update
+    on
+    public.route for each row execute function min_max_route_difficulty_of_crag();
+create trigger crag_route_count after
+insert
+    or
+delete
+    on
+    public.route for each row execute function recount_routes_of_crag();

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,6 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
+  "testTimeout": 30000,
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {


### PR DESCRIPTION
- added endpoint for moving sectors to another crag with services that manage related entities
- added endpoint for moving routes between sectors with an option to merge with another route
- moved some ascent validation from activity route service to a helper so it can be used elsewhere
- added triggers to a script to be used by the test database
 
Route merge is mostly covered by e2e tests, but it would be nice to test this manually with https://github.com/plezanje-net/web/pull/445