### PR TITLE
Add cascade delete to crag property

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "dev": "npm run start:dev",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/src/activities/entities/activity.entity.ts
+++ b/src/activities/entities/activity.entity.ts
@@ -31,7 +31,7 @@ export class Activity extends BaseEntity {
   @Field()
   id: string;
 
-  @ManyToOne(() => Crag, { nullable: true })
+  @ManyToOne(() => Crag, { nullable: true, onDelete: 'SET NULL' })
   @Field(() => Crag, { nullable: true })
   crag: Promise<Crag>;
   @Column({ nullable: true })

--- a/src/crags/entities/crag-property.entity.ts
+++ b/src/crags/entities/crag-property.entity.ts
@@ -6,7 +6,7 @@ import { Crag } from './crag.entity';
 @Entity()
 @ObjectType()
 export class CragProperty extends BaseProperty {
-  @ManyToOne(() => Crag)
+  @ManyToOne(() => Crag, { onDelete: 'CASCADE' })
   @Field(() => Crag)
   crag: Promise<Crag>;
   @Column()

--- a/src/crags/entities/crag.entity.ts
+++ b/src/crags/entities/crag.entity.ts
@@ -105,48 +105,29 @@ export class Crag extends BaseEntity {
   @Column({ nullable: true })
   legacy: string;
 
-  @ManyToOne(
-    () => Area,
-    area => area.crags,
-    { nullable: true },
-  )
+  @ManyToOne(() => Area, (area) => area.crags, { nullable: true })
   @Field(() => Area, { nullable: true })
   area: Promise<Area>;
   @Column({ nullable: true })
   areaId: string;
 
-  @ManyToOne(
-    () => Peak,
-    peak => peak.crags,
-    { nullable: true },
-  )
+  @ManyToOne(() => Peak, (peak) => peak.crags, { nullable: true })
   @Field(() => Peak, { nullable: true })
   peak: Promise<Peak>;
   @Column({ nullable: true })
   peakId: string;
 
-  @ManyToOne(
-    () => Country,
-    country => country.crags,
-  )
+  @ManyToOne(() => Country, (country) => country.crags)
   @Field(() => Country)
   country: Promise<Country>;
   @Column({ nullable: true })
   countryId: string;
 
-  @OneToMany(
-    () => Sector,
-    sector => sector.crag,
-    { nullable: true },
-  )
+  @OneToMany(() => Sector, (sector) => sector.crag, { nullable: true })
   @Field(() => [Sector])
   sectors: Promise<Sector[]>;
 
-  @OneToMany(
-    () => Route,
-    route => route.crag,
-    { nullable: true },
-  )
+  @OneToMany(() => Route, (route) => route.crag, { nullable: true })
   @Field(() => [Route])
   routes: Promise<Route[]>;
 
@@ -172,29 +153,19 @@ export class Crag extends BaseEntity {
   @JoinTable()
   books: Book[];
 
-  @OneToMany(
-    () => Comment,
-    comment => comment.crag,
-    { nullable: true },
-  )
+  @OneToMany(() => Comment, (comment) => comment.crag, { nullable: true })
   @Field(() => [Comment])
   comments: Promise<Comment[]>;
 
-  @OneToMany(
-    () => Image,
-    image => image.crag,
-    { nullable: true },
-  )
+  @OneToMany(() => Image, (image) => image.crag, { nullable: true })
   @Field(() => [Image])
   images: Promise<Image[]>;
 
   routeCount: number;
 
-  @OneToMany(
-    () => Activity,
-    activity => activity.crag,
-    { nullable: true },
-  )
+  @OneToMany(() => Activity, (activity) => activity.crag, {
+    nullable: true,
+  })
   activities: Promise<Activity[]>;
 
   @ManyToOne(() => User)

--- a/src/migration/1679818310991-cascadeDeleteCragPropertyFK.ts
+++ b/src/migration/1679818310991-cascadeDeleteCragPropertyFK.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class cascadeDeleteCragPropertyFK1679818310991 implements MigrationInterface {
+    name = 'cascadeDeleteCragPropertyFK1679818310991'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "crag_property" DROP CONSTRAINT "FK_66aa9b1be26f87337745c8c82ef"`);
+        await queryRunner.query(`ALTER TABLE "crag_property" ADD CONSTRAINT "FK_66aa9b1be26f87337745c8c82ef" FOREIGN KEY ("cragId") REFERENCES "crag"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "crag_property" DROP CONSTRAINT "FK_66aa9b1be26f87337745c8c82ef"`);
+        await queryRunner.query(`ALTER TABLE "crag_property" ADD CONSTRAINT "FK_66aa9b1be26f87337745c8c82ef" FOREIGN KEY ("cragId") REFERENCES "crag"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/migration/1679821202524-cascadeNullifyCragActivityFK.ts
+++ b/src/migration/1679821202524-cascadeNullifyCragActivityFK.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class cascadeNullifyCragActivityFK1679821202524 implements MigrationInterface {
+    name = 'cascadeNullifyCragActivityFK1679821202524'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "activity" DROP CONSTRAINT "FK_626d254ca76bdbb0be1aef6b7c9"`);
+        await queryRunner.query(`ALTER TABLE "activity" ADD CONSTRAINT "FK_626d254ca76bdbb0be1aef6b7c9" FOREIGN KEY ("cragId") REFERENCES "crag"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "activity" DROP CONSTRAINT "FK_626d254ca76bdbb0be1aef6b7c9"`);
+        await queryRunner.query(`ALTER TABLE "activity" ADD CONSTRAINT "FK_626d254ca76bdbb0be1aef6b7c9" FOREIGN KEY ("cragId") REFERENCES "crag"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}


### PR DESCRIPTION
When an empty crag is being deleted, also its properties should be automatically deleted, because there is a FK constraint on them. Using cascade delete.
best way to test is: for example with crag Shaddocs -> move all its sectors to another crag, then try deleting it (before running migration). Then run migration and try again...