### PR TITLE
Set user as active whenever a password is successfully reset.

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -70,9 +70,9 @@ export class AuthService {
       return null;
     }
 
-    const userRoles = (await user.roles).map(r => r.role);
+    const userRoles = (await user.roles).map((r) => r.role);
 
-    if (roles.filter(r => !userRoles.includes(r)).length > 0) {
+    if (roles.filter((r) => !userRoles.includes(r)).length > 0) {
       return null;
     }
 

--- a/src/users/resolvers/users.resolver.ts
+++ b/src/users/resolvers/users.resolver.ts
@@ -57,7 +57,7 @@ export class UsersResolver {
   }
 
   // TODO: auth?
-  @Query(returns => User)
+  @Query((returns) => User)
   async user(
     @Args('email') email: string,
     @Args('id', { nullable: true }) id: string,
@@ -152,7 +152,7 @@ export class UsersResolver {
     return user.firstname + ' ' + user.lastname;
   }
 
-  @ResolveField('clubs', returns => [ClubMember])
+  @ResolveField('clubs', (returns) => [ClubMember])
   async getClubs(
     @Parent() user: User,
     @CurrentUser() currentUser: User,

--- a/src/users/services/users.service.ts
+++ b/src/users/services/users.service.ts
@@ -101,6 +101,7 @@ export class UsersService {
     user.passwordToken = null;
     user.lastPasswordChange = new Date();
     user.password = await bcrypt.hash(password, 10);
+    user.isActive = true; // reset link also counts as a user email confirmation, so set user to active (in case that confirmation email was never clicked when registering)
 
     return this.usersRepository.save(user).then(() => true);
   }


### PR DESCRIPTION
There was a sequence of actions that might have left the user locked out of her account:
- new user registers
- user loses the registration confirmation link (spam, accidentally deletes mail, forgets to click it...)
- user returns to page and tries to reset the password
- password is successfully reset but user still cannot log in because her active status is false

simple fix: set user active status to true whenever a password is successfully reset.

to test, run above scenario on master to see it fail then on this branch to see it is fixed.
