### PR TITLE
Fix bug where comments are not shown if not logged in.

### DIFF
--- a/src/crags/loaders/route-comments.loader.ts
+++ b/src/crags/loaders/route-comments.loader.ts
@@ -1,30 +1,18 @@
 import DataLoader from 'dataloader';
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Comment } from '../entities/comment.entity';
 import { CommentsService } from '../services/comments.service';
 import { NestDataLoader } from '../../core/interceptors/data-loader.interceptor';
-import { CONTEXT } from '@nestjs/graphql';
-import { User } from '../../users/entities/user.entity';
 
 @Injectable()
 export class RouteCommentsLoader implements NestDataLoader<string, Comment[]> {
-  currentUser: User = null;
-
-  constructor(
-    private readonly commentsService: CommentsService,
-    @Inject(CONTEXT) private context: any,
-  ) {
-    this.currentUser = this.context.req.user;
-  }
+  constructor(private readonly commentsService: CommentsService) {}
 
   generateDataLoader(): DataLoader<string, Comment[]> {
     return new DataLoader<string, Comment[]>(async (keys) => {
-      const comments = await this.commentsService.find(
-        {
-          routeIds: keys.map((k) => k),
-        },
-        this.currentUser,
-      );
+      const comments = await this.commentsService.find({
+        routeIds: keys.map((k) => k),
+      });
 
       const routeComments: { [key: string]: Comment[] } = {};
 

--- a/src/crags/resolvers/crags.resolver.ts
+++ b/src/crags/resolvers/crags.resolver.ts
@@ -189,16 +189,10 @@ export class CragsResolver {
 
   @ResolveField('comments', () => [Comment])
   @UseGuards(UserAuthGuard)
-  async getComments(
-    @Parent() crag: Crag,
-    @CurrentUser() currentUser: User,
-  ): Promise<Comment[]> {
-    const comments = await this.commentsService.find(
-      {
-        cragId: crag.id,
-      },
-      currentUser,
-    );
+  async getComments(@Parent() crag: Crag): Promise<Comment[]> {
+    const comments = await this.commentsService.find({
+      cragId: crag.id,
+    });
 
     return comments;
   }

--- a/src/crags/services/comments.service.ts
+++ b/src/crags/services/comments.service.ts
@@ -86,10 +86,7 @@ export class CommentsService {
     return this.commentsRepository.remove(comment).then(() => true);
   }
 
-  async find(
-    params: FindCommentsInput = {},
-    currentUser: User,
-  ): Promise<Comment[]> {
+  async find(params: FindCommentsInput = {}): Promise<Comment[]> {
     const options: FindManyOptions = {
       order: {},
       where: {},
@@ -109,15 +106,6 @@ export class CommentsService {
 
     if (params.type != null) {
       options.where['type'] = params.type;
-    }
-
-    if (!currentUser) {
-      options.relations = {
-        crag: true,
-      };
-      options.where['crag'] = {
-        isHidden: false,
-      };
     }
 
     options.order = { created: 'DESC' };


### PR DESCRIPTION
Comments were not being shown for guest users at all (except on home page). 
Comment previews were also not being loaded on route list.

There was a bug introduced with https://github.com/plezanje-net/api/pull/147
(linked to: https://github.com/plezanje-net/web/pull/439)

I am not sure why the condition in comments service:
`    if (!currentUser) {
      options.relations = {
        crag: true,
      };
      options.where['crag'] = {
        isHidden: false,
      };
    }`
was even added as comments can only be accessed via crag, via route, via latestComments query, which all already take care of publish status and isHidden status.
(even if we kept this condition it is wrong, as it only takes crag comments into account and fails for route comments --> bug symptom)

Removed some other related unnecessary code.

Might have missed something though, so pls test :)

