### PR TITLE
Change case of AscentType enum keys and values to all lowercase.

### DIFF
--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -15,50 +15,50 @@ import { Pitch } from '../../crags/entities/pitch.entity';
 import { User } from '../../users/entities/user.entity';
 
 export enum AscentType {
-  ONSIGHT = 'onsight',
-  FLASH = 'flash',
-  REDPOINT = 'redpoint',
-  REPEAT = 'repeat',
-  ALLFREE = 'allfree',
-  AID = 'aid',
-  ATTEMPT = 'attempt',
-  T_ONSIGHT = 't_onsight',
-  T_FLASH = 't_flash',
-  T_REDPOINT = 't_redpoint',
-  T_REPEAT = 't_repeat',
-  T_ALLFREE = 't_allfree',
-  T_AID = 't_aid',
-  T_ATTEMPT = 't_attempt',
-  TICK = 'tick',
+  onsight = 'onsight',
+  flash = 'flash',
+  redpoint = 'redpoint',
+  repeat = 'repeat',
+  allfree = 'allfree',
+  aid = 'aid',
+  attempt = 'attempt',
+  t_onsight = 't_onsight',
+  t_flash = 't_flash',
+  t_redpoint = 't_redpoint',
+  t_repeat = 't_repeat',
+  t_allfree = 't_allfree',
+  t_aid = 't_aid',
+  t_attempt = 't_attempt',
+  tick = 'tick',
 }
 registerEnumType(AscentType, {
   name: 'AscentType',
 });
 
 export const tickAscentTypes = new Set([
-  AscentType.ONSIGHT,
-  AscentType.FLASH,
-  AscentType.REDPOINT,
-  AscentType.REPEAT,
+  AscentType.onsight,
+  AscentType.flash,
+  AscentType.redpoint,
+  AscentType.repeat,
 ]);
 
 export const firstTickAscentTypes = new Set([
-  AscentType.ONSIGHT,
-  AscentType.FLASH,
-  AscentType.REDPOINT,
+  AscentType.onsight,
+  AscentType.flash,
+  AscentType.redpoint,
 ]);
 
 export const trTickAscentTypes = new Set([
-  AscentType.T_ONSIGHT,
-  AscentType.T_FLASH,
-  AscentType.T_REDPOINT,
-  AscentType.T_REPEAT,
+  AscentType.t_onsight,
+  AscentType.t_flash,
+  AscentType.t_redpoint,
+  AscentType.t_repeat,
 ]);
 
 export const firstTrTickAscentTypes = new Set([
-  AscentType.T_ONSIGHT,
-  AscentType.T_FLASH,
-  AscentType.T_REDPOINT,
+  AscentType.t_onsight,
+  AscentType.t_flash,
+  AscentType.t_redpoint,
 ]);
 
 export enum PublishType {
@@ -115,7 +115,7 @@ export class ActivityRoute extends BaseEntity {
   @Column({
     type: 'enum',
     enum: AscentType,
-    default: AscentType.REDPOINT,
+    default: AscentType.redpoint,
   })
   @Field((type) => AscentType)
   ascentType: AscentType;

--- a/src/activities/entities/activity-route.entity.ts
+++ b/src/activities/entities/activity-route.entity.ts
@@ -62,10 +62,10 @@ export const firstTrTickAscentTypes = new Set([
 ]);
 
 export enum PublishType {
-  PUBLIC = 'public',
-  CLUB = 'club',
-  LOG = 'log',
-  PRIVATE = 'private',
+  public = 'public',
+  club = 'club',
+  log = 'log',
+  private = 'private',
 }
 registerEnumType(PublishType, {
   name: 'PublishType',
@@ -123,7 +123,7 @@ export class ActivityRoute extends BaseEntity {
   @Column({
     type: 'enum',
     enum: PublishType,
-    default: PublishType.PRIVATE,
+    default: PublishType.private,
   })
   @Field((type) => PublishType)
   publish: PublishType;

--- a/src/activities/services/activity-routes.service.ts
+++ b/src/activities/services/activity-routes.service.ts
@@ -247,8 +247,8 @@ export class ActivityRoutesService {
     // boulders cannot be onsighted at all
     if (routeTypeId === 'boulder') {
       if (
-        ascentType === AscentType.ONSIGHT ||
-        ascentType === AscentType.T_ONSIGHT
+        ascentType === AscentType.onsight ||
+        ascentType === AscentType.t_onsight
       )
         return false;
     }
@@ -256,10 +256,10 @@ export class ActivityRoutesService {
     // already tried routes cannot be onsighted or flashed
     if (routeTried) {
       if (
-        ascentType === AscentType.ONSIGHT ||
-        ascentType === AscentType.T_ONSIGHT ||
-        ascentType === AscentType.FLASH ||
-        ascentType === AscentType.T_FLASH
+        ascentType === AscentType.onsight ||
+        ascentType === AscentType.t_onsight ||
+        ascentType === AscentType.flash ||
+        ascentType === AscentType.t_flash
       )
         return false;
     }
@@ -267,26 +267,26 @@ export class ActivityRoutesService {
     // already ticked routes cannot be redpointed (flash, sight included above)
     if (routeTicked) {
       if (
-        ascentType === AscentType.REDPOINT ||
-        ascentType === AscentType.T_REDPOINT
+        ascentType === AscentType.redpoint ||
+        ascentType === AscentType.t_redpoint
       )
         return false;
     }
 
     // routes one already 'ticked' on toprope cannot be tr redpointed
     if (routeTrTicked) {
-      if (ascentType === AscentType.T_REDPOINT) {
+      if (ascentType === AscentType.t_redpoint) {
         return false;
       }
     }
 
     // routes not ticked before cannot be repeated
-    if (ascentType === AscentType.REPEAT && !routeTicked) {
+    if (ascentType === AscentType.repeat && !routeTicked) {
       return false;
     }
 
     // routes not ticked (real or tr) before cannot be toprope repeated
-    if (ascentType === AscentType.T_REPEAT && !(routeTicked || routeTrTicked)) {
+    if (ascentType === AscentType.t_repeat && !(routeTicked || routeTrTicked)) {
       return false;
     }
 

--- a/src/crags/entities/crag.entity.ts
+++ b/src/crags/entities/crag.entity.ts
@@ -41,34 +41,34 @@ export enum CragType {
 }
 
 export enum Orientation {
-  NORTH = 'north',
-  NORTHEAST = 'northeast',
-  EAST = 'east',
-  SOUTHEAST = 'southeast',
-  SOUTH = 'south',
-  SOUTHWEST = 'southwest',
-  WEST = 'west',
-  NORTHWEST = 'northwest',
+  north = 'north',
+  northeast = 'northeast',
+  east = 'east',
+  southeast = 'southeast',
+  south = 'south',
+  southwest = 'southwest',
+  west = 'west',
+  northwest = 'northwest',
 }
 registerEnumType(Orientation, {
   name: 'Orientation',
 });
 
 export enum WallAngle {
-  SLAB = 'slab',
-  VERTICAL = 'vertical',
-  OVERHANG = 'overhang',
-  ROOF = 'roof',
+  slab = 'slab',
+  vertical = 'vertical',
+  overhang = 'overhang',
+  roof = 'roof',
 }
 registerEnumType(WallAngle, {
   name: 'WallAngle',
 });
 
 export enum Season {
-  SPRING = 'spring',
-  SUMMER = 'summer',
-  AUTUMN = 'autumn',
-  WINTER = 'winter',
+  spring = 'spring',
+  summer = 'summer',
+  autumn = 'autumn',
+  winter = 'winter',
 }
 registerEnumType(Season, {
   name: 'Season',

--- a/src/crags/utils/calculate-scores.ts
+++ b/src/crags/utils/calculate-scores.ts
@@ -50,35 +50,35 @@ function calculateScore(
   const scoreTypeFactor = scoreType === 'order' ? 1 : 0;
 
   switch (ascentType) {
-    case AscentType.ONSIGHT:
+    case AscentType.onsight:
       return difficulty + 100;
-    case AscentType.FLASH:
+    case AscentType.flash:
       return difficulty + 50;
-    case AscentType.REDPOINT:
+    case AscentType.redpoint:
       return difficulty;
-    case AscentType.REPEAT:
+    case AscentType.repeat:
       return (difficulty - 10) * scoreTypeFactor;
-    case AscentType.ALLFREE:
+    case AscentType.allfree:
       return difficulty * 0.01 * scoreTypeFactor;
-    case AscentType.AID:
+    case AscentType.aid:
       return difficulty * 0.001 * scoreTypeFactor;
-    case AscentType.ATTEMPT:
+    case AscentType.attempt:
       return difficulty * 0.0001 * scoreTypeFactor;
-    case AscentType.T_ONSIGHT:
+    case AscentType.t_onsight:
       return (difficulty + 100) * 0.0001 * scoreTypeFactor;
-    case AscentType.T_FLASH:
+    case AscentType.t_flash:
       return (difficulty + 50) * 0.0001 * scoreTypeFactor;
-    case AscentType.T_REDPOINT:
+    case AscentType.t_redpoint:
       return difficulty * 0.0001 * scoreTypeFactor;
-    case AscentType.T_REPEAT:
+    case AscentType.t_repeat:
       return (difficulty - 10) * 0.0001 * scoreTypeFactor;
-    case AscentType.T_ALLFREE:
+    case AscentType.t_allfree:
       return difficulty * 0.01 * 0.0001 * scoreTypeFactor;
-    case AscentType.T_AID:
+    case AscentType.t_aid:
       return difficulty * 0.001 * 0.0001 * scoreTypeFactor;
-    case AscentType.T_ATTEMPT:
+    case AscentType.t_attempt:
       return difficulty * 0.0001 * 0.0001 * scoreTypeFactor;
-    case AscentType.TICK:
+    case AscentType.tick:
       // TODO: what is TICK ascent type, and is it even used?? prob not, 1 ar in db... suggest removal, discuss
       return 0;
   }

--- a/src/crags/utils/convert-ascents.ts
+++ b/src/crags/utils/convert-ascents.ts
@@ -49,7 +49,7 @@ async function convertFirstTickAfterToRepeat(
     );
 
     // Convert it to repeat
-    futureTick.ascentType = AscentType.REPEAT;
+    futureTick.ascentType = AscentType.repeat;
     await queryRunner.manager.save(futureTick);
     sideEffects.push({ before: futureTickBeforeChange, after: futureTick });
   }
@@ -86,7 +86,7 @@ async function convertFirstTrTickAfterToTrRepeat(
     );
 
     // Convert it to toprope repeat
-    futureTrTick.ascentType = AscentType.T_REPEAT;
+    futureTrTick.ascentType = AscentType.t_repeat;
     await queryRunner.manager.save(futureTrTick);
     sideEffects.push({
       before: futureTrTickBeforeChange,
@@ -110,7 +110,7 @@ async function convertFirstSightOrFlashAfterToRedpoint(
     .where('ar.route_id = :routeId', { routeId: routeId })
     .andWhere('ar.user_id = :userId', { userId: userId })
     .andWhere('ar.ascent_type IN (:...aTypes)', {
-      aTypes: [AscentType.ONSIGHT, AscentType.FLASH],
+      aTypes: [AscentType.onsight, AscentType.flash],
     })
     .andWhere('ar.date > :arDate', { arDate: date })
     .getOne(); // If data is valid there can only be one such ascent logged (or none)
@@ -126,7 +126,7 @@ async function convertFirstSightOrFlashAfterToRedpoint(
     );
 
     // Convert it to redpoint
-    futureSightOrFlash.ascentType = AscentType.REDPOINT;
+    futureSightOrFlash.ascentType = AscentType.redpoint;
     await queryRunner.manager.save(futureSightOrFlash);
     sideEffects.push({
       before: futureSightOrFlashBeforeChange,
@@ -150,7 +150,7 @@ async function convertFirstTrSightOrFlashAfterToTrRedpoint(
     .where('ar.route_id = :routeId', { routeId: routeId })
     .andWhere('ar.user_id = :userId', { userId: userId })
     .andWhere('ar.ascent_type IN (:...aTypes)', {
-      aTypes: [AscentType.T_ONSIGHT, AscentType.T_FLASH],
+      aTypes: [AscentType.t_onsight, AscentType.t_flash],
     })
     .andWhere('ar.date > :arDate', { arDate: date })
     .getOne(); // If data is valid there can only be one such ascent logged (or none)
@@ -166,7 +166,7 @@ async function convertFirstTrSightOrFlashAfterToTrRedpoint(
     );
 
     // Convert it to toprope redpoint
-    futureTrSightOrFlash.ascentType = AscentType.T_REDPOINT;
+    futureTrSightOrFlash.ascentType = AscentType.t_redpoint;
     await queryRunner.manager.save(futureTrSightOrFlash);
     sideEffects.push({
       before: futureTrSightOrFlashBeforeChange,

--- a/test/e2e/activity.e2e-spec.ts
+++ b/test/e2e/activity.e2e-spec.ts
@@ -130,7 +130,7 @@ describe('Activity', () => {
 
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithPublicRoutes.activityRoutes.publicActivityRoute.id}', '${AscentType.ONSIGHT}', 'public', '${mockData.activities.activityWithPublicRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithPublicRoutes.activityRoutes.publicActivityRoute.id}', '${AscentType.onsight}', 'public', '${mockData.activities.activityWithPublicRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activity with only private activity routes
@@ -141,7 +141,7 @@ describe('Activity', () => {
 
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithPrivateRoutes.activityRoutes.privateActivityRoute.id}', '${AscentType.REPEAT}', 'private', '${mockData.activities.activityWithPrivateRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithPrivateRoutes.activityRoutes.privateActivityRoute.id}', '${AscentType.repeat}', 'private', '${mockData.activities.activityWithPrivateRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activity with only log activity routes
@@ -152,7 +152,7 @@ describe('Activity', () => {
 
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithLogRoutes.activityRoutes.logActivityRoute.id}', '${AscentType.REPEAT}', 'log', '${mockData.activities.activityWithLogRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithLogRoutes.activityRoutes.logActivityRoute.id}', '${AscentType.repeat}', 'log', '${mockData.activities.activityWithLogRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activty with mixed activity routes (public, private, log)
@@ -163,15 +163,15 @@ describe('Activity', () => {
 
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.publicActivityRoute.id}', '${AscentType.REPEAT}', 'public', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.publicActivityRoute.id}', '${AscentType.repeat}', 'public', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.logActivityRoute.id}', '${AscentType.REPEAT}', 'log', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.logActivityRoute.id}', '${AscentType.repeat}', 'log', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.privateActivityRoute.id}', '${AscentType.REPEAT}', 'private', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityWithMixedRoutes.activityRoutes.privateActivityRoute.id}', '${AscentType.repeat}', 'private', '${mockData.activities.activityWithMixedRoutes.id}', '${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activity in a draft crag
@@ -181,7 +181,7 @@ describe('Activity', () => {
     );
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityInDraftCrag.activityRoutes.activityRoute1.id}', '${AscentType.REPEAT}', 'public', '${mockData.activities.activityInDraftCrag.id}', '${mockData.crags.draftCrag.sectors.draftSector.routes.draftRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityInDraftCrag.activityRoutes.activityRoute1.id}', '${AscentType.repeat}', 'public', '${mockData.activities.activityInDraftCrag.id}', '${mockData.crags.draftCrag.sectors.draftSector.routes.draftRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activity in an in_review crag
@@ -191,7 +191,7 @@ describe('Activity', () => {
     );
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityInInReviewCrag.activityRoutes.activityRoute1.id}', '${AscentType.REPEAT}', 'public', '${mockData.activities.activityInInReviewCrag.id}', '${mockData.crags.inReviewCrag.sectors.inReviewSector.routes.inReviewRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityInInReviewCrag.activityRoutes.activityRoute1.id}', '${AscentType.repeat}', 'public', '${mockData.activities.activityInInReviewCrag.id}', '${mockData.crags.inReviewCrag.sectors.inReviewSector.routes.inReviewRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
 
     // add activity in a published crag and draft sector
@@ -201,7 +201,7 @@ describe('Activity', () => {
     );
     await queryRunner.query(
       `INSERT INTO activity_route (id, ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
-      VALUES ('${mockData.activities.activityInPublishedCragDraftSector.activityRoutes.activityRoute1.id}', '${AscentType.REPEAT}', 'public', '${mockData.activities.activityInPublishedCragDraftSector.id}', '${mockData.crags.publishedCrag.sectors.draftSector.routes.draftRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
+      VALUES ('${mockData.activities.activityInPublishedCragDraftSector.activityRoutes.activityRoute1.id}', '${AscentType.repeat}', 'public', '${mockData.activities.activityInPublishedCragDraftSector.id}', '${mockData.crags.publishedCrag.sectors.draftSector.routes.draftRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)`,
     );
   });
 

--- a/test/e2e/activity.e2e-spec.ts
+++ b/test/e2e/activity.e2e-spec.ts
@@ -308,7 +308,7 @@ describe('Activity', () => {
       response.body.data.activities.items.filter(
         (a) =>
           a.routes.filter(
-            (ar) => ![PublishType.PUBLIC].includes(ar.publish.toLowerCase()),
+            (ar) => ![PublishType.public].includes(ar.publish.toLowerCase()),
           ).length > 0,
       ).length;
     expect(numOfNonPublicActivityRoutes).toEqual(0);
@@ -317,7 +317,7 @@ describe('Activity', () => {
       response.body.data.activities.items.filter(
         (a) =>
           !a.routes.some((ar) =>
-            [PublishType.PUBLIC].includes(ar.publish.toLowerCase()),
+            [PublishType.public].includes(ar.publish.toLowerCase()),
           ),
       ).length;
     expect(numOfActivitiesWithNoPublicActivityRoutes).toEqual(0);

--- a/test/e2e/activityMutations.e2e-spec.ts
+++ b/test/e2e/activityMutations.e2e-spec.ts
@@ -105,7 +105,7 @@ describe('ActivityMutations', () => {
               routes: [
                 {
                   ascentType: "${AscentType.onsight}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}"
                 }

--- a/test/e2e/activityMutations.e2e-spec.ts
+++ b/test/e2e/activityMutations.e2e-spec.ts
@@ -104,7 +104,7 @@ describe('ActivityMutations', () => {
               },
               routes: [
                 {
-                  ascentType: "${AscentType.ONSIGHT}",
+                  ascentType: "${AscentType.onsight}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockData.crags.publishedCrag.sectors.publishedSector.routes.publishedRoute.id}"

--- a/test/e2e/activityRoutes.e2e-spec.ts
+++ b/test/e2e/activityRoutes.e2e-spec.ts
@@ -61,85 +61,85 @@ describe('Activity', () => {
               routes: [
                 {
                   ascentType: "${AscentType.onsight}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[0].id}"
                 },
                 {
                   ascentType: "${AscentType.flash}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[1].id}"
                 },
                 {
                   ascentType: "${AscentType.redpoint}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[2].id}"                
                 },
                 {
                   ascentType: "${AscentType.repeat}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[2].id}"
                 }
                 {
                   ascentType: "${AscentType.allfree}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[3].id}"
                 },
                 {
                   ascentType: "${AscentType.aid}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[4].id}"
                 },
                 {
                   ascentType: "${AscentType.attempt}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[5].id}"
                 },
                 {
                   ascentType: "${AscentType.t_onsight}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[6].id}"
                 },
                 {
                   ascentType: "${AscentType.t_flash}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[7].id}"
                 },
                 {
                   ascentType: "${AscentType.t_redpoint}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[8].id}"
                 },
                 {
                   ascentType: "${AscentType.t_repeat}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[8].id}"
                 },
                 {
                   ascentType: "${AscentType.t_allfree}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[9].id}"
                 },
                 {
                   ascentType: "${AscentType.t_aid}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[10].id}"
                 }
                 {
                   ascentType: "${AscentType.t_attempt}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[11].id}"
                 }                                

--- a/test/e2e/activityRoutes.e2e-spec.ts
+++ b/test/e2e/activityRoutes.e2e-spec.ts
@@ -60,85 +60,85 @@ describe('Activity', () => {
               },
               routes: [
                 {
-                  ascentType: "${AscentType.ONSIGHT}",
+                  ascentType: "${AscentType.onsight}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[0].id}"
                 },
                 {
-                  ascentType: "${AscentType.FLASH}",
+                  ascentType: "${AscentType.flash}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[1].id}"
                 },
                 {
-                  ascentType: "${AscentType.REDPOINT}",
+                  ascentType: "${AscentType.redpoint}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[2].id}"                
                 },
                 {
-                  ascentType: "${AscentType.REPEAT}",
+                  ascentType: "${AscentType.repeat}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[2].id}"
                 }
                 {
-                  ascentType: "${AscentType.ALLFREE}",
+                  ascentType: "${AscentType.allfree}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[3].id}"
                 },
                 {
-                  ascentType: "${AscentType.AID}",
+                  ascentType: "${AscentType.aid}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[4].id}"
                 },
                 {
-                  ascentType: "${AscentType.ATTEMPT}",
+                  ascentType: "${AscentType.attempt}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[5].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_ONSIGHT}",
+                  ascentType: "${AscentType.t_onsight}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[6].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_FLASH}",
+                  ascentType: "${AscentType.t_flash}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[7].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_REDPOINT}",
+                  ascentType: "${AscentType.t_redpoint}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[8].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_REPEAT}",
+                  ascentType: "${AscentType.t_repeat}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[8].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_ALLFREE}",
+                  ascentType: "${AscentType.t_allfree}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[9].id}"
                 },
                 {
-                  ascentType: "${AscentType.T_AID}",
+                  ascentType: "${AscentType.t_aid}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[10].id}"
                 }
                 {
-                  ascentType: "${AscentType.T_ATTEMPT}",
+                  ascentType: "${AscentType.t_attempt}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[11].id}"
@@ -182,7 +182,7 @@ describe('Activity', () => {
       queryResponse.body.data.activity.routes.filter(
         (r) =>
           r.route.id == mockRoutes[0].id &&
-          !(r.ascentType.toLowerCase() == AscentType.REPEAT),
+          !(r.ascentType == AscentType.repeat),
       )[0].orderScore,
     ).toBe(mockRoutes[0].difficulty + 100);
     expect(
@@ -207,15 +207,13 @@ describe('Activity', () => {
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
-          r.route.id == mockRoutes[2].id &&
-          r.ascentType.toLowerCase() != AscentType.REPEAT,
+          r.route.id == mockRoutes[2].id && r.ascentType != AscentType.repeat,
       )[0].orderScore,
     ).toBe(mockRoutes[2].difficulty);
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
-          r.route.id == mockRoutes[2].id &&
-          r.ascentType.toLowerCase() != AscentType.REPEAT,
+          r.route.id == mockRoutes[2].id && r.ascentType != AscentType.repeat,
       )[0].rankingScore,
     ).toBe(mockRoutes[2].difficulty);
 
@@ -223,15 +221,13 @@ describe('Activity', () => {
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
-          r.route.id == mockRoutes[2].id &&
-          r.ascentType.toLowerCase() == AscentType.REPEAT,
+          r.route.id == mockRoutes[2].id && r.ascentType == AscentType.repeat,
       )[0].orderScore,
     ).toBe(mockRoutes[2].difficulty - 10);
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
-          r.route.id == mockRoutes[2].id &&
-          r.ascentType.toLowerCase() == AscentType.REPEAT,
+          r.route.id == mockRoutes[2].id && r.ascentType == AscentType.repeat,
       )[0].rankingScore,
     ).toBe(0);
 
@@ -300,14 +296,14 @@ describe('Activity', () => {
       queryResponse.body.data.activity.routes.filter(
         (r) =>
           r.route.id == mockRoutes[8].id &&
-          r.ascentType.toLowerCase() != AscentType.T_REPEAT,
+          r.ascentType.toLowerCase() != AscentType.t_repeat,
       )[0].orderScore,
     ).toBe(mockRoutes[8].difficulty * 0.0001);
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
           r.route.id == mockRoutes[8].id &&
-          r.ascentType.toLowerCase() != AscentType.T_REPEAT,
+          r.ascentType.toLowerCase() != AscentType.t_repeat,
       )[0].rankingScore,
     ).toBe(0);
 
@@ -316,14 +312,14 @@ describe('Activity', () => {
       queryResponse.body.data.activity.routes.filter(
         (r) =>
           r.route.id == mockRoutes[8].id &&
-          r.ascentType.toLowerCase() == AscentType.T_REPEAT,
+          r.ascentType.toLowerCase() == AscentType.t_repeat,
       )[0].orderScore,
     ).toBe((mockRoutes[8].difficulty - 10) * 0.0001);
     expect(
       queryResponse.body.data.activity.routes.filter(
         (r) =>
           r.route.id == mockRoutes[8].id &&
-          r.ascentType.toLowerCase() == AscentType.T_REPEAT,
+          r.ascentType.toLowerCase() == AscentType.t_repeat,
       )[0].rankingScore,
     ).toBe(0);
 

--- a/test/e2e/routeMigration.e2e-spec.ts
+++ b/test/e2e/routeMigration.e2e-spec.ts
@@ -233,7 +233,7 @@ describe('RouteMigration', () => {
               routes: [
                 {
                   ascentType: "${AscentType.onsight}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[0].id}"
                 }                
@@ -316,7 +316,7 @@ describe('RouteMigration', () => {
               routes: [
                 {
                   ascentType: "${AscentType.redpoint}",
-                  publish: "${PublishType.PUBLIC}",
+                  publish: "${PublishType.public}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[1].id}"
                 }                

--- a/test/e2e/routeMigration.e2e-spec.ts
+++ b/test/e2e/routeMigration.e2e-spec.ts
@@ -59,8 +59,8 @@ describe('RouteMigration', () => {
     await queryRunner.query(
       `INSERT INTO activity_route (ascent_type, publish, activity_id, route_id, user_id, date, order_score, ranking_score)
         VALUES
-          ('${AscentType.ONSIGHT}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityAcrossSectors.date}', 1000, 1000),
-          ('${AscentType.ONSIGHT}', 'log', '${mockData.activities.activityWithDuplicateRoute.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityWithDuplicateRoute.date}', 1000, 1000)
+          ('${AscentType.onsight}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityAcrossSectors.date}', 1000, 1000),
+          ('${AscentType.onsight}', 'log', '${mockData.activities.activityWithDuplicateRoute.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', '${mockData.activities.activityWithDuplicateRoute.date}', 1000, 1000)
           `,
     );
 
@@ -164,7 +164,7 @@ describe('RouteMigration', () => {
 
   it('should change ascent types if invalid state happens after merge', async () => {
     const onsightAscentsOfRoute = await queryRunner.query(
-      `SELECT * FROM activity_route WHERE route_id = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}' AND user_id = '${mockData.users.basicUser1.id}' AND ascent_type = '${AscentType.ONSIGHT}'`,
+      `SELECT * FROM activity_route WHERE route_id = '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}' AND user_id = '${mockData.users.basicUser1.id}' AND ascent_type = '${AscentType.onsight}'`,
     );
     expect(onsightAscentsOfRoute.length).toBe(1);
   });
@@ -232,7 +232,7 @@ describe('RouteMigration', () => {
               },
               routes: [
                 {
-                  ascentType: "${AscentType.ONSIGHT}",
+                  ascentType: "${AscentType.onsight}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[0].id}"
@@ -315,7 +315,7 @@ describe('RouteMigration', () => {
               },
               routes: [
                 {
-                  ascentType: "${AscentType.REDPOINT}",
+                  ascentType: "${AscentType.redpoint}",
                   publish: "${PublishType.PUBLIC}",
                   date: "2017-03-07",
                   routeId: "${mockRoutes[1].id}"

--- a/test/e2e/sectorMigration.e2e-spec.ts
+++ b/test/e2e/sectorMigration.e2e-spec.ts
@@ -49,10 +49,10 @@ describe('SectorMigration', () => {
     await queryRunner.query(
       `INSERT INTO activity_route (ascent_type, publish, activity_id, route_id, user_id, order_score, ranking_score)
       VALUES 
-        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
-        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
-        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
-        ('${AscentType.ALLFREE}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)
+        ('${AscentType.allfree}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
+        ('${AscentType.allfree}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.firstSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
+        ('${AscentType.allfree}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.firstRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000),
+        ('${AscentType.allfree}', 'log', '${mockData.activities.activityAcrossSectors.id}', '${mockData.crags.cragWithMultipleSectors.sectors.secondSector.routes.secondRoute.id}', '${mockData.users.basicUser1.id}', 1000, 1000)
       `,
     );
   });

--- a/test/e2e/user-delete.e2e-spec.ts
+++ b/test/e2e/user-delete.e2e-spec.ts
@@ -56,14 +56,14 @@ describe('UserDelete', () => {
       [
         {
           route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
-          ascentType: AscentType.REDPOINT,
+          ascentType: AscentType.redpoint,
           publishType: PublishType.PRIVATE,
           votedDifficulty: 1100,
           votedStarRating: 2,
         },
         {
           route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[1],
-          ascentType: AscentType.ONSIGHT,
+          ascentType: AscentType.onsight,
           publishType: PublishType.PUBLIC,
         },
       ],
@@ -81,7 +81,7 @@ describe('UserDelete', () => {
     await logRoutes(app, mockData.users.basicUser2, mockData.crags.simpleCrag, [
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
-        ascentType: AscentType.REDPOINT,
+        ascentType: AscentType.redpoint,
         publishType: PublishType.PRIVATE,
         votedDifficulty: 1200,
         votedStarRating: 2,
@@ -90,7 +90,7 @@ describe('UserDelete', () => {
     await logRoutes(app, mockData.users.basicUser3, mockData.crags.simpleCrag, [
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
-        ascentType: AscentType.REDPOINT,
+        ascentType: AscentType.redpoint,
         publishType: PublishType.PRIVATE,
         votedDifficulty: 1300,
         votedStarRating: 2,
@@ -102,7 +102,7 @@ describe('UserDelete', () => {
     await logRoutes(app, mockData.users.basicUser4, mockData.crags.simpleCrag, [
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
-        ascentType: AscentType.REDPOINT,
+        ascentType: AscentType.redpoint,
         publishType: PublishType.PRIVATE,
         votedStarRating: 2,
       },
@@ -110,7 +110,7 @@ describe('UserDelete', () => {
     await logRoutes(app, mockData.users.basicUser5, mockData.crags.simpleCrag, [
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
-        ascentType: AscentType.REDPOINT,
+        ascentType: AscentType.redpoint,
         publishType: PublishType.PRIVATE,
         votedStarRating: 2,
       },

--- a/test/e2e/user-delete.e2e-spec.ts
+++ b/test/e2e/user-delete.e2e-spec.ts
@@ -57,14 +57,14 @@ describe('UserDelete', () => {
         {
           route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
           ascentType: AscentType.redpoint,
-          publishType: PublishType.PRIVATE,
+          publishType: PublishType.private,
           votedDifficulty: 1100,
           votedStarRating: 2,
         },
         {
           route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[1],
           ascentType: AscentType.onsight,
-          publishType: PublishType.PUBLIC,
+          publishType: PublishType.public,
         },
       ],
     );
@@ -82,7 +82,7 @@ describe('UserDelete', () => {
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
         ascentType: AscentType.redpoint,
-        publishType: PublishType.PRIVATE,
+        publishType: PublishType.private,
         votedDifficulty: 1200,
         votedStarRating: 2,
       },
@@ -91,7 +91,7 @@ describe('UserDelete', () => {
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
         ascentType: AscentType.redpoint,
-        publishType: PublishType.PRIVATE,
+        publishType: PublishType.private,
         votedDifficulty: 1300,
         votedStarRating: 2,
       },
@@ -103,7 +103,7 @@ describe('UserDelete', () => {
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
         ascentType: AscentType.redpoint,
-        publishType: PublishType.PRIVATE,
+        publishType: PublishType.private,
         votedStarRating: 2,
       },
     ]);
@@ -111,7 +111,7 @@ describe('UserDelete', () => {
       {
         route: mockData.crags.simpleCrag.sectors.simpleSector1.routes[0],
         ascentType: AscentType.redpoint,
-        publishType: PublishType.PRIVATE,
+        publishType: PublishType.private,
         votedStarRating: 2,
       },
     ]);


### PR DESCRIPTION
when using nests registerEnumType codegen generates an enum type that can be used in fe as well.

but codegen only considers enum keys of the source, which in generated.ts become values. if we want matching values (db has all lowercase) we need to use lowercase keys when defining an enum in an entity. 
not too nice, since it violates naming convention for enums in typescript, but don't sea a better option to make this work.

test also with https://github.com/plezanje-net/next-web/pull/49